### PR TITLE
A couple of fixes for path handling

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -87,7 +87,7 @@ def _check_key_names(criteria, annotations, changed_rosdeps, key_counts):
                 problems.add(
                     "Keys which contain only pip rules should end in '-pip'")
                 annotations.append(Annotation(
-                    'rosdep/python.yaml',
+                    file,
                     k.__lines__,
                     f"This key should{'' if pip_only else ' not'} "
                     "end in '-pip'"))

--- a/rosdistro_reviewer/yaml_changes.py
+++ b/rosdistro_reviewer/yaml_changes.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Any
 from typing import Iterable
 from typing import Mapping
@@ -84,8 +86,9 @@ def get_changed_yaml(
     data = {}
     if head_ref is not None:
         for yaml_path in paths:
+            git_yaml_path = str(PurePosixPath(Path(yaml_path)))
             data[yaml_path] = yaml.load(
-                repo.tree(head_ref)[yaml_path].data_stream,
+                repo.tree(head_ref)[git_yaml_path].data_stream,
                 Loader=AnnotatedSafeLoader)
     else:
         for yaml_path in paths:


### PR DESCRIPTION
It appears that indexing into the files in a git tree only works with POSIX paths, so the Windows native paths need to be converted.

Additionally, I made a bad assumption about the 'python.yaml' file name in the rosdep analyzer. That change should have no effect on POSIX systems, and makes Windows runs more consistent.