### PR TITLE
Move temporary venv outside the working directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,15 +13,16 @@ runs:
     - name: Set up rosdistro-reviewer
       shell: bash
       run: |
-        python -m venv .rosdistro-reviewer-venv
-        . .rosdistro-reviewer-venv/bin/activate
+        python -m venv ${{ runner.temp }}/.rosdistro-reviewer-venv
+        . ${{ runner.temp }}/.rosdistro-reviewer-venv/bin/activate
         python -m pip install "${{ github.action_path }}[github]" --quiet
     - name: Generate automated review
       shell: bash
       run: |
-        . .rosdistro-reviewer-venv/bin/activate
+        . ${{ runner.temp }}/.rosdistro-reviewer-venv/bin/activate
         rosdistro-reviewer \
           --log-base /dev/null \
+          --log-level DEBUG \
           --target-ref ${{ github.event.pull_request.base.sha }} \
           --head-ref ${{ github.event.pull_request.head.sha }} \
           --github-pull-request \


### PR DESCRIPTION
This should prevent this tool from traversing into the venv, which may contain files which don't pass our checks.