### PR TITLE
Ensure git.Repo instances are closed

### DIFF
--- a/rosdistro_reviewer/yaml_changes.py
+++ b/rosdistro_reviewer/yaml_changes.py
@@ -79,14 +79,13 @@ def get_changed_yaml(
     if not changes:
         return None
 
-    repo = Repo(path)
-
     data = {}
     if head_ref is not None:
-        for yaml_path in paths:
-            data[yaml_path] = yaml.load(
-                repo.tree(head_ref)[yaml_path].data_stream,
-                Loader=AnnotatedSafeLoader)
+        with Repo(path) as repo:
+            for yaml_path in paths:
+                data[yaml_path] = yaml.load(
+                    repo.tree(head_ref)[yaml_path].data_stream,
+                    Loader=AnnotatedSafeLoader)
     else:
         for yaml_path in paths:
             with (path / yaml_path).open('r') as f:


### PR DESCRIPTION
This is mostly whitespace changes to use git.Repo instances as a context manager so they're closed properly.