### PR TITLE
Normalize paths discovered in `head_ref` tree

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -314,7 +314,7 @@ def _get_changed_rosdeps(
             if not isinstance(tree, Tree):
                 return None, None
             rosdep_files = [
-                str(item.path)
+                str(Path(item.path))
                 for item in tree.traverse(predicate=_is_yaml_blob)
                 if isinstance(item, Blob)
             ]


### PR DESCRIPTION
Since git always uses POSIX path separators, we need to normalize the paths we discover by inspecting the `head_ref` tree.