### PR TITLE
Do not create a log directory by default

### DIFF
--- a/rosdistro_reviewer/command.py
+++ b/rosdistro_reviewer/command.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+import os
 from typing import Any
 
 from colcon_core.command \
@@ -29,6 +30,7 @@ def main(*args: str, **kwargs: str) -> Any:
         'environment_variable_group_name':
             'rosdistro_reviewer.environment_variable',
         'default_verb': ReviewVerb,
+        'default_log_base': os.devnull,
         **kwargs,
     }
     return colcon_main(*args, **colcon_kwargs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ long_description_content_type = text/markdown
 [options]
 python_requires = >=3.6
 install_requires =
-    colcon-core>=0.17.1
+    colcon-core>=0.18.0
     GitPython
     rosdep
     unidiff

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [rosdistro-reviewer]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.17.1), python3-git, python3-rosdep-modules | python3-rosdep2, python3-unidiff, python3-yaml, yamllint
+Depends3: python3-colcon-core (>= 0.18.0), python3-git, python3-rosdep-modules | python3-rosdep2, python3-unidiff, python3-yaml, yamllint
 Recommends3: python3-github
 Suite: focal jammy noble bullseye bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
The automatic log directory creation isn't really useful for this tool. The log directory can still be enabled by the `--log-base` argument. This feature is only available in colcon-core 0.18.0 and newer.