### PR TITLE
Do not register extension points with colcon

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,6 @@ markers =
     linter
 
 [options.entry_points]
-colcon_core.extension_point =
-    rosdistro_reviewer.element_analyzer = rosdistro_reviewer.element_analyzer:ElementAnalyzerExtensionPoint
-    rosdistro_reviewer.submitter = rosdistro_reviewer.submitter:ReviewSubmitterExtensionPoint
 console_scripts =
     rosdistro-reviewer = rosdistro_reviewer.command:main
 rosdistro_reviewer.environment_variable =


### PR DESCRIPTION
As an independent tool built on colcon's framework, this tool should not register its extension points as colcon extension points. This should prevent it from appearing in colcon-devtools output, namely version-check.

This isn't to say that extension point registration and presence in colcon-devtools wouldn't provide any benefit, this is an effort to avoid "kitchen sinking" colcon as a command line tool.