### PR TITLE
A couple of fixes for modern linter releases

### DIFF
--- a/rosdistro_reviewer/git_lines.py
+++ b/rosdistro_reviewer/git_lines.py
@@ -19,7 +19,7 @@ def _rangeify(sequence: Iterable[int]) -> Iterable[range]:
 
     for item in sequence:
         if chunk_last != item - 1:
-            if chunk_start is not None:
+            if chunk_start is not None and chunk_last is not None:
                 yield range(chunk_start, chunk_last + 1)
             chunk_start = item
         chunk_last = item
@@ -77,8 +77,11 @@ def get_added_lines(
             if not diff.b_path:
                 continue
             patch = f"""--- {diff.a_path if diff.a_path else '/dev/null'}
-+++ {diff.b_path}
-{diff.diff.decode()}"""
++++ {diff.b_path}"""
+            if isinstance(diff.diff, str):
+                patch += '\n' + diff.diff
+            elif isinstance(diff.diff, bytes):
+                patch += '\n' + diff.diff.decode()
             patchset = unidiff.PatchSet(patch)
             for file in patchset:
                 for hunk in file:

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -11,7 +11,6 @@ spell_check_words_path = Path(__file__).parent / 'spell_check.words'
 
 @pytest.fixture(scope='module')
 def known_words() -> List[str]:
-    global spell_check_words_path
     return spell_check_words_path.read_text().splitlines()
 
 


### PR DESCRIPTION
There should be no functional changes resulting from these modifications.

Addresses:
```
rosdistro_reviewer/git_lines.py:23: error: Unsupported operand types for + ("None" and "int")  [operator]
rosdistro_reviewer/git_lines.py:23: note: Left operand is of type "int | None"
rosdistro_reviewer/git_lines.py:81: error: Item "str" of "str | bytes | None" has no attribute "decode"  [union-attr]
rosdistro_reviewer/git_lines.py:81: error: Item "None" of "str | bytes | None" has no attribute "decode"  [union-attr]
test/test_spell_check.py:14:5: F999 `global spell_check_words_path` is unused: name is never assigned in scope
```