### PR TITLE
Fix function references in API documentation

### DIFF
--- a/rosdistro_reviewer/element_analyzer/__init__.py
+++ b/rosdistro_reviewer/element_analyzer/__init__.py
@@ -72,7 +72,7 @@ def analyze(
     :param path: Path on disk to the git repository
     :param extensions: The element analyzer extensions to use, if `None` is
       passed use the extensions provided by
-      :function:`get_element_analyzer_extensions`
+      :func:`get_element_analyzer_extensions`
     :param target_ref: The git ref to base the diff from
     :param head_ref: The git ref where the changes have been made
     :returns: A new review instance, or None if no

--- a/rosdistro_reviewer/submitter/__init__.py
+++ b/rosdistro_reviewer/submitter/__init__.py
@@ -61,7 +61,7 @@ def add_review_submitter_arguments(parser, *, extensions=None) -> None:
     :param parser: The argument parser
     :param extensions: The review submitter extensions to use, if `None` is
       passed use the extensions provided by
-      :function:`get_review_submitter_extensions`
+      :func:`get_review_submitter_extensions`
     """
     if extensions is None:
         extensions = get_review_submitter_extensions()
@@ -78,7 +78,7 @@ def submit_review(args, review, *, extensions=None) -> None:
     :param review: The code review to submit
     :param extensions: The review submitter extensions to use, if `None` is
       passed use the extensions provided by
-      :function:`get_review_submitter_extensions`
+      :func:`get_review_submitter_extensions`
     """
     if extensions is None:
         extensions = get_review_submitter_extensions()


### PR DESCRIPTION
According to sphinx-apidoc, this should be ':func:' not ':function:'.