### PR TITLE
Address some deprecations with bleeding-edge dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,13 +6,12 @@ classifiers =
     Development Status :: 4 - Beta
     Environment :: Console
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX
     Programming Language :: Python
     Topic :: Software Development :: Testing
-license = Apache License, Version 2.0
+license = Apache-2.0
 description = Automation for analyzing changes to the rosdep database and rosdistro index
 long_description = file: README.rst
 
@@ -48,6 +47,7 @@ exclude =
     test.*
 
 [tool:pytest]
+asyncio_default_fixture_loop_scope = function
 junit_suite_name = rosdistro-reviewer
 markers =
     flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ exclude =
     test.*
 
 [tool:pytest]
-asyncio_default_fixture_loop_scope = function
 junit_suite_name = rosdistro-reviewer
 markers =
     flake8


### PR DESCRIPTION
```
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```

```
PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.

The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
```