### PR TITLE
Handle some edge cases in rosdep syntax

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -116,7 +116,7 @@ def _check_key_names(criteria, annotations, changed_rosdeps, key_counts):
         for key, rules in changes.items():
             if not getattr(key, '__lines__', None):
                 continue
-            ubuntu_rule = rules.get('ubuntu', {})
+            ubuntu_rule = (rules or {}).get('ubuntu', {})
             if isinstance(ubuntu_rule, dict) and '*' in ubuntu_rule:
                 ubuntu_rule = ubuntu_rule['*']
             if isinstance(ubuntu_rule, dict):
@@ -170,7 +170,7 @@ def _check_platforms(criteria, annotations, changed_rosdeps):
         ))
         for changes in changed_rosdeps.values()
         for rules in changes.values()
-        for os, rule in rules.items()
+        for os, rule in (rules or {}).items()
     ):
         return
 
@@ -184,7 +184,7 @@ def _check_platforms(criteria, annotations, changed_rosdeps):
     # New rules for unsupported OSs are not allowed
     for file, changes in changed_rosdeps.items():
         for rules in changes.values():
-            for os, rule in rules.items():
+            for os, rule in (rules or {}).items():
                 if os not in os_keys and getattr(os, '__lines__', None):
                     recommendation = Recommendation.DISAPPROVE
                     problems.add(
@@ -231,7 +231,7 @@ def _check_installers(criteria, annotations, changed_rosdeps):
         )
         for changes in changed_rosdeps.values()
         for rules in changes.values()
-        for os, rule in rules.items()
+        for os, rule in (rules or {}).items()
     ):
         return
 
@@ -242,7 +242,7 @@ def _check_installers(criteria, annotations, changed_rosdeps):
 
     for file, changes in changed_rosdeps.items():
         for rules in changes.values():
-            for os, rule in rules.items():
+            for os, rule in (rules or {}).items():
                 if os == '*' or not isinstance(rule, dict):
                     continue
                 try:

--- a/test/test_rosdep_checks.py
+++ b/test/test_rosdep_checks.py
@@ -128,6 +128,13 @@ CONTROL_RULES = {
                 },
             },
         },
+        'none-key': None,
+        'none-rules': {
+            'debian': None,
+            'ubuntu': {
+                'apt': None,
+            },
+        },
     },
     'python.yaml': {
         'python3-control-bravo': {


### PR DESCRIPTION
These cases might not be usable or supported by rosdep itself, but it would be nice if rosdistro-reviewer didn't fall over if they're encountered.