### PR TITLE
Add a new pip key check for existing system key

### DIFF
--- a/test/test_rosdep_checks.py
+++ b/test/test_rosdep_checks.py
@@ -101,10 +101,8 @@ EXISTING_RULES = {
         },
     },
     'python.yaml': {
-        'python.yaml': {
-            'python3-existing-india': {
-                'fedora': ['python3-existing-india'],
-            },
+        'python3-existing-india': {
+            'fedora': ['python3-existing-india'],
         },
     },
 }
@@ -148,10 +146,10 @@ CONTROL_RULES = {
             },
             'ubuntu': ['python3-control-bravo'],
         },
-        'python3-control-bravo-pip': {
+        'python3-control-kilo-pip': {
             '*': {
                 'pip': {
-                    'packages': ['python3-control-bravo'],
+                    'packages': ['python3-control-kilo'],
                 },
             },
         },
@@ -273,6 +271,18 @@ VIOLATIONS = {
                         'pip': {
                             'packages': ['juliet'],
                         },
+                    },
+                },
+            },
+        },
+    },
+    'K': {
+        # There is already a non-pip key "python3-existing-india"
+        'python.yaml': {
+            'python3-existing-india-pip': {
+                '*': {
+                    'pip': {
+                        'packages': ['existing-india'],
                     },
                 },
             },


### PR DESCRIPTION
There is a policy which prohibits adding `*-pip` keys when there are system packages available to satisfy the requirement. While rosdistro-reviewer doesn't yet interact with packaging databases, we can at least check that there isn't already a non-pip key present in the database.

Closes #48
Part of #30