### PR TITLE
Don't suggest that keys should have 't64' suffix

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -64,7 +64,10 @@ EOL_PLATFORMS = {
 }
 
 
-DEB_SUFFIX_MATCHER = re.compile(r'([a-zA-Z]+)\d+(-|$)')
+# Two cases here:
+# 1. Name segments with trailing digits drop the digits
+# 2. Names ending with `t64` drop that suffix
+DEB_SUFFIX_MATCHER = re.compile(r'([a-zA-Z]+?)(?:t64$|\d+(-|$))')
 
 
 def _no_suffixes(packages):

--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -64,16 +64,18 @@ EOL_PLATFORMS = {
 }
 
 
-# Two cases here:
-# 1. Name segments with trailing digits drop the digits
-# 2. Names ending with `t64` drop that suffix
-DEB_SUFFIX_MATCHER = re.compile(r'([a-zA-Z]+?)(?:t64$|\d+(-|$))')
+DEB_SUFFIX_MATCHER = re.compile(r'([a-zA-Z]+)\d+(-|$)')
 
 
 def _no_suffixes(packages):
     for package in packages:
-        package, success = DEB_SUFFIX_MATCHER.subn(r'\1\2', package)
-        if success:
+        changed = False
+        if package.endswith('t64'):
+            package = package[:-3]
+            changed = True
+        package, substituted = DEB_SUFFIX_MATCHER.subn(r'\1\2', package)
+        changed |= substituted
+        if changed:
             yield package
 
 

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -27,6 +27,8 @@ juliet
 lenny
 libcontrol
 libdelta
+libecho
+libechot
 linter
 linting
 login

--- a/test/test_rosdep_checks.py
+++ b/test/test_rosdep_checks.py
@@ -138,6 +138,9 @@ CONTROL_RULES = {
                 'apt': None,
             },
         },
+        'libecho': {
+            'ubuntu': ['libechot64'],
+        },
     },
     'python.yaml': {
         'python3-control-bravo': {

--- a/test/test_rosdep_checks.py
+++ b/test/test_rosdep_checks.py
@@ -141,6 +141,9 @@ CONTROL_RULES = {
         'libecho': {
             'ubuntu': ['libechot64'],
         },
+        'foxtrot4t64': {
+            'ubuntu': ['foxtrot4t64'],
+        },
     },
     'python.yaml': {
         'python3-control-bravo': {


### PR DESCRIPTION
It appears that Ubuntu intends for this to be a short-lived package naming paradigm, so we shouldn't propagate it to rosdep key names.