### PR TITLE
feat: flag binary release changes across multiple distributions

### DIFF
--- a/rosdistro_reviewer/element_analyzer/multidistro.py
+++ b/rosdistro_reviewer/element_analyzer/multidistro.py
@@ -1,0 +1,74 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from pathlib import Path
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from colcon_core.logging import colcon_logger
+from colcon_core.plugin_system import satisfies_version
+from rosdistro_reviewer.element_analyzer \
+    import ElementAnalyzerExtensionPoint
+from rosdistro_reviewer.git_lines import get_added_lines
+from rosdistro_reviewer.review import Annotation
+from rosdistro_reviewer.review import Criterion
+from rosdistro_reviewer.review import Recommendation
+
+logger = colcon_logger.getChild(__name__)
+
+
+class MultiDistroAnalyzer(ElementAnalyzerExtensionPoint):
+    """Element analyzer for changes to multiple rosdistro distributions."""
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            ElementAnalyzerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def analyze(  # noqa: D102
+        self,
+        path: Path,
+        target_ref: Optional[str] = None,
+        head_ref: Optional[str] = None,
+    ) -> Tuple[Optional[List[Criterion]], Optional[List[Annotation]]]:
+        criteria: List[Criterion] = []
+        annotations: List[Annotation] = []
+
+        changes = get_added_lines(
+            path, target_ref=target_ref, head_ref=head_ref)
+        if not changes:
+            return None, None
+
+        distros = set()
+        distro_changes = {}
+
+        for filename in changes.keys():
+            path_obj = Path(filename)
+            if len(path_obj.parts) < 2:
+                continue
+            if path_obj.name != 'distribution.yaml':
+                continue
+
+            distros.add(path_obj.parent.name)
+            distro_changes[path_obj] = changes[filename]
+
+        if len(distros) <= 1:
+            return None, None
+
+        logger.info('Performing analysis on multi-distribution changes...')
+
+        recommendation = Recommendation.DISAPPROVE
+        message = 'Changes to multiple distributions are not allowed ' \
+                  'in a single PR'
+
+        for file_path, lines in distro_changes.items():
+            annotations.append(Annotation(
+                str(file_path),
+                lines[0],
+                'This distribution should not be modified in the same PR '
+                'as others'))
+
+        criteria.append(Criterion(recommendation, message))
+
+        return criteria, annotations

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ rosdistro_reviewer.environment_variable =
     log_level = rosdistro_reviewer.command:LOG_LEVEL_ENVIRONMENT_VARIABLE
 rosdistro_reviewer.element_analyzer =
     rosdep = rosdistro_reviewer.element_analyzer.rosdep:RosdepAnalyzer
+    multidistro = rosdistro_reviewer.element_analyzer.multidistro:MultiDistroAnalyzer
     yamllint = rosdistro_reviewer.element_analyzer.yamllint:YamllintAnalyzer
 rosdistro_reviewer.submitter =
     github = rosdistro_reviewer.submitter.github:GitHubSubmitter

--- a/test/test_multidistro_checks.py
+++ b/test/test_multidistro_checks.py
@@ -19,35 +19,64 @@ def test_multidistro_check():
         assert criteria is None
         assert annotations is None
 
-    # Case 2: Single distro change (ignored)
-    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines:
-        mock_get_lines.return_value = {
-            'rolling/distribution.yaml': [range(1, 2)]
-        }
-        criteria, annotations = analyzer.analyze(Path('.'))
-        assert criteria is None
-        assert annotations is None
-
-    # Case 3: Multiple distro changes (flagged)
-    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines:
+    # Case 2: Multi-distro changes but only source (ignored)
+    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines, \
+         patch('rosdistro_reviewer.element_analyzer.multidistro.get_changed_yaml') as mock_get_yaml, \
+         patch('rosdistro_reviewer.element_analyzer.multidistro.prune_changed_yaml'):
+        
         mock_get_lines.return_value = {
             'rolling/distribution.yaml': [range(1, 2)],
             'iron/distribution.yaml': [range(3, 4)],
         }
+        
+        # Simulate source-only changes (no 'release' key in pruned data)
+        mock_get_yaml.side_effect = [
+             {'rolling/distribution.yaml': {'repositories': {'repo_a': {'source': {}}}}},
+             {'iron/distribution.yaml': {'repositories': {'repo_b': {'source': {}}}}}
+        ]
+        
+        criteria, annotations = analyzer.analyze(Path('.'))
+        assert criteria is None
+        assert annotations is None
+
+    # Case 3: Multi-distro release changes (flagged)
+    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines, \
+         patch('rosdistro_reviewer.element_analyzer.multidistro.get_changed_yaml') as mock_get_yaml, \
+         patch('rosdistro_reviewer.element_analyzer.multidistro.prune_changed_yaml'):
+        
+        mock_get_lines.return_value = {
+            'rolling/distribution.yaml': [range(1, 2)],
+            'iron/distribution.yaml': [range(3, 4)],
+        }
+        
+        # Simulate release changes
+        mock_get_yaml.side_effect = [
+             {'rolling/distribution.yaml': {'repositories': {'repo_a': {'release': {}}}}},
+             {'iron/distribution.yaml': {'repositories': {'repo_b': {'release': {}}}}}
+        ]
+        
         criteria, annotations = analyzer.analyze(Path('.'))
         assert criteria is not None
-        assert annotations is not None
         assert len(criteria) == 1
-        assert len(annotations) == 2
         assert criteria[0].recommendation == Recommendation.DISAPPROVE
-        assert 'Changes to multiple distributions' in criteria[0].rationale
+        assert 'Binary release changes' in criteria[0].rationale
 
-    # Case 4: Changes to non-distribution files (ignored)
-    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines:
+    # Case 4: Mixed changes (1 release, 1 source) - (ignored)
+    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines, \
+         patch('rosdistro_reviewer.element_analyzer.multidistro.get_changed_yaml') as mock_get_yaml, \
+         patch('rosdistro_reviewer.element_analyzer.multidistro.prune_changed_yaml'):
+        
         mock_get_lines.return_value = {
-            'rolling/release.yaml': [range(1, 2)],
-            'iron/source.yaml': [range(3, 4)],
+            'rolling/distribution.yaml': [range(1, 2)],
+            'iron/distribution.yaml': [range(3, 4)],
         }
+        
+        # Simulate mixed changes
+        mock_get_yaml.side_effect = [
+             {'rolling/distribution.yaml': {'repositories': {'repo_a': {'release': {}}}}},
+             {'iron/distribution.yaml': {'repositories': {'repo_b': {'source': {}}}}}
+        ]
+        
         criteria, annotations = analyzer.analyze(Path('.'))
         assert criteria is None
         assert annotations is None

--- a/test/test_multidistro_checks.py
+++ b/test/test_multidistro_checks.py
@@ -1,0 +1,53 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from pathlib import Path
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from rosdistro_reviewer.element_analyzer.multidistro import MultiDistroAnalyzer
+from rosdistro_reviewer.review import Recommendation
+
+
+def test_multidistro_check():
+    analyzer = MultiDistroAnalyzer()
+
+    # Case 1: No checks run when no changes
+    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines:
+        mock_get_lines.return_value = {}
+        criteria, annotations = analyzer.analyze(Path('.'))
+        assert criteria is None
+        assert annotations is None
+
+    # Case 2: Single distro change (ignored)
+    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines:
+        mock_get_lines.return_value = {
+            'rolling/distribution.yaml': [range(1, 2)]
+        }
+        criteria, annotations = analyzer.analyze(Path('.'))
+        assert criteria is None
+        assert annotations is None
+
+    # Case 3: Multiple distro changes (flagged)
+    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines:
+        mock_get_lines.return_value = {
+            'rolling/distribution.yaml': [range(1, 2)],
+            'iron/distribution.yaml': [range(3, 4)],
+        }
+        criteria, annotations = analyzer.analyze(Path('.'))
+        assert criteria is not None
+        assert annotations is not None
+        assert len(criteria) == 1
+        assert len(annotations) == 2
+        assert criteria[0].recommendation == Recommendation.DISAPPROVE
+        assert 'Changes to multiple distributions' in criteria[0].rationale
+
+    # Case 4: Changes to non-distribution files (ignored)
+    with patch('rosdistro_reviewer.element_analyzer.multidistro.get_added_lines') as mock_get_lines:
+        mock_get_lines.return_value = {
+            'rolling/release.yaml': [range(1, 2)],
+            'iron/source.yaml': [range(3, 4)],
+        }
+        criteria, annotations = analyzer.analyze(Path('.'))
+        assert criteria is None
+        assert annotations is None


### PR DESCRIPTION
Recommend not merging changes that are across multiple distributions.

Closes #50 and #51.