### PR TITLE
Target specific commit when posting GitHub reviews

### DIFF
--- a/rosdistro_reviewer/element_analyzer/__init__.py
+++ b/rosdistro_reviewer/element_analyzer/__init__.py
@@ -78,9 +78,21 @@ def analyze(
     :returns: A new review instance, or None if no
       analyzer extensions performed any analysis
     """
+    # We delay this import until after the GitPython
+    # logger has already been configured to avoid DEBUG
+    # messages on the console at import time
+    from git import Repo
     if extensions is None:
         extensions = get_element_analyzer_extensions()
-    review = Review()
+    if target_ref or head_ref:
+        # Resolve the target_ref and head_ref from a commit-ish
+        # to an actual SHA
+        with Repo(path) as repo:
+            if target_ref:
+                target_ref = repo.commit(target_ref).hexsha
+            if head_ref:
+                head_ref = repo.commit(head_ref).hexsha
+    review = Review(head_ref=head_ref)
     for analyzer_name, extension in extensions.items():
         criteria, annotations = extension.analyze(path, target_ref, head_ref)
 

--- a/rosdistro_reviewer/review.py
+++ b/rosdistro_reviewer/review.py
@@ -108,10 +108,15 @@ Criterion = namedtuple('Criterion', ('recommendation', 'rationale'))
 class Review:
     """High-level representation of a rosdistro code review."""
 
-    def __init__(self):
-        """Initialize a new instance of a Review."""
+    def __init__(self, *, head_ref: Optional[str] = None):
+        """
+        Initialize a new instance of a Review.
+
+        :param head_ref: The git ref where the changes have been made
+        """
         self._annotations: List[Annotation] = []
         self._elements: Dict[str, List[Criterion]] = {}
+        self._head_ref = head_ref
 
     @property
     def annotations(self) -> List[Annotation]:
@@ -122,6 +127,11 @@ class Review:
     def elements(self) -> Dict[str, List[Criterion]]:
         """Get the mapping of element name to criteria collection."""
         return self._elements
+
+    @property
+    def head_ref(self) -> Optional[str]:
+        """Get the git ref where the changes have been made."""
+        return self._head_ref
 
     @property
     def recommendation(self) -> Recommendation:

--- a/rosdistro_reviewer/submitter/github.py
+++ b/rosdistro_reviewer/submitter/github.py
@@ -3,6 +3,8 @@
 
 import logging
 import os
+from typing import Any
+from typing import Dict
 
 from colcon_core.environment_variable import EnvironmentVariable
 from colcon_core.logging import colcon_logger
@@ -115,6 +117,10 @@ class GitHubSubmitter(ReviewSubmitterExtensionPoint):
         repo = github.get_repo(repo_id)
         pr = repo.get_pull(pr_id)
 
+        create_review_args: Dict[str, Any] = {}
+        if review.head_ref:
+            create_review_args['commit'] = repo.get_commit(review.head_ref)
+
         message = review.summarize()
         recommendation = review.recommendation
 
@@ -128,4 +134,5 @@ class GitHubSubmitter(ReviewSubmitterExtensionPoint):
         pr.create_review(
             body=message,
             event=RECOMMENDATION_EVENTS[recommendation],
-            comments=comments)
+            comments=comments,
+            **create_review_args)

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -18,6 +18,7 @@ fixturenames
 fred
 gentoo
 github
+hexsha
 https
 india
 iterdir

--- a/test/test_verb_review.py
+++ b/test/test_verb_review.py
@@ -70,6 +70,8 @@ def test_verb_review(empty_repo):
     context = CommandContext(
         command_name='rosdistro-reviewer',
         args=Mock())
+    context.args.head_ref = None
+    context.args.target_ref = None
 
     with patch(
         'rosdistro_reviewer.verb.review.Path.cwd',


### PR DESCRIPTION
The existing behavior is to post the review on whatever the current HEAD of the PR happens to be. If a developer iterates on a PR faster than the review can be posted, it's possible for the review to be presented on newer file contents.

If possible, target the specific commit that we analyzed so that GitHub presents the review on the right content.