### PR TITLE
feat: add automated native existence check for rosdep keys

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -38,10 +38,11 @@ EOL_PLATFORMS = {
         'buster',
     },
     'fedora': {
-        str(n) for n in range(21, 39)
+        '21', '22', '23', '24', '25', '26', '27', '28', '29', '30',
+        '31', '32', '33', '34', '35', '36', '37', '38'
     },
     'rhel': {
-        str(n) for n in range(3, 8)
+        '3', '4', '5', '6', '7'
     },
     'ubuntu': {
         'trusty',
@@ -350,7 +351,17 @@ def _check_suitability(criteria, annotations, changed_rosdeps, key_counts):
     else:
         message = 'New keys appear suitable for rosdep'
 
+    _validate_markdown(message)
     criteria.append(Criterion(recommendation, message))
+
+
+def _validate_markdown(content: str) -> None:
+    """Ensure generated markdown is structurally sound."""
+    # Check for balanced backticks
+    if len(re.findall(r'(?<!`)`(?!`)', content)) % 2 != 0:
+        raise ValueError('Unbalanced single backticks in markdown')
+    if len(re.findall(r'```', content)) % 2 != 0:
+        raise ValueError('Unbalanced triple backticks in markdown')
 
 
 def _check_native_existence(criteria, annotations, changed_rosdeps):
@@ -436,6 +447,7 @@ def _check_native_existence(criteria, annotations, changed_rosdeps):
     else:
         message = 'No native Ubuntu/Debian packages found for new pip keys'
 
+    _validate_markdown(message)
     criteria.append(Criterion(recommendation, message))
 
 

--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -356,7 +356,7 @@ def _check_suitability(criteria, annotations, changed_rosdeps, key_counts):
 def _check_native_existence(criteria, annotations, changed_rosdeps):
     # Bypass check if no new keys were added
     if not any(
-        getattr(key, "__lines__", None)
+        getattr(key, '__lines__', None)
         for changes in changed_rosdeps.values()
         for key in changes.keys()
     ):
@@ -368,68 +368,73 @@ def _check_native_existence(criteria, annotations, changed_rosdeps):
     # Native packages are strongly preferred
     for file, changes in changed_rosdeps.items():
         for key, rules in changes.items():
-            if not getattr(key, "__lines__", None):
+            if not getattr(key, '__lines__', None):
                 continue
 
             is_pip = isinstance(rules, dict) and any(
-                isinstance(rule, dict) and "pip" in rule.keys()
+                isinstance(rule, dict) and 'pip' in rule.keys()
                 for rule in rules.values()
             )
             if not is_pip:
                 continue
 
-            package_name = key.replace("-pip", "")
+            package_name = key.replace('-pip', '')
             search_names = [package_name]
-            if package_name.startswith("python3-"):
+            if package_name.startswith('python3-'):
                 search_names.append(package_name[8:])
-            elif not package_name.startswith("python-"):
-                search_names.append("python3-" + package_name)
+            elif not package_name.startswith('python-'):
+                search_names.append('python3-' + package_name)
 
             found_any = False
             found_urls = []
             for name in set(search_names):
-                for platform in ["ubuntu", "debian"]:
-                    url = f"https://packages.{platform}.com/search?keywords={quote(name)}&searchon=names&suite=all&section=all"
+                for platform in ['ubuntu', 'debian']:
+                    url = f'https://packages.{platform}.com/search' \
+                          f'?keywords={quote(name)}&searchon=names' \
+                          f'&suite=all&section=all'
                     try:
                         result = subprocess.run(
-                            ["curl", "-s", "-L", url],
+                            ['curl', '-s', '-L', url],
                             capture_output=True,
                             text=True,
                             timeout=10,
+                            check=True,
                         )
                         if (
-                            f"<h3>Package {name}</h3>" in result.stdout
-                            or f"Exact hits" in result.stdout
+                            f'<h3>Package {name}</h3>' in result.stdout
+                            or 'Exact hits' in result.stdout
                             or f'class="binpkg">{name}</a>' in result.stdout
                         ):
                             found_any = True
-                            found_urls.append(f"{platform}: {name}")
-                    except Exception as e:
-                        logger.error(f"Error checking {platform}: {e}")
+                            found_urls.append(f'{platform}: {name}')
+                    except subprocess.SubprocessError as e:
+                        logger.error(f'Error checking {platform}: {e}')
 
             if found_any:
                 recommendation = min(recommendation, Recommendation.NEUTRAL)
                 problems.add(
-                    f"Found native package(s) for `{key}`, prefer native over pip: "
-                    + ", ".join(found_urls)
+                    f'Found native package(s) for `{key}`, '
+                    f'prefer native over pip: {", ".join(found_urls)}'
                 )
                 annotations.append(
                     Annotation(
                         file,
                         key.__lines__,
-                        f"Found native package(s) for `{key}`, prefer native over pip",
+                        f'Found native package(s) for `{key}`, '
+                        'prefer native over pip',
                     )
                 )
 
     if problems:
-        message = "\n- ".join(
+        message = '\n- '.join(
             [
-                "There are problems with native existence for new rosdep keys:",
+                'There are problems with native existence for new '
+                'rosdep keys:',
             ]
             + sorted(problems)
         )
     else:
-        message = "No native Ubuntu/Debian packages found for new pip keys"
+        message = 'No native Ubuntu/Debian packages found for new pip keys'
 
     criteria.append(Criterion(recommendation, message))
 

--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -4,11 +4,13 @@
 from pathlib import Path
 from pathlib import PurePosixPath
 import re
+import subprocess
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from urllib.parse import quote
 
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
@@ -351,6 +353,87 @@ def _check_suitability(criteria, annotations, changed_rosdeps, key_counts):
     criteria.append(Criterion(recommendation, message))
 
 
+def _check_native_existence(criteria, annotations, changed_rosdeps):
+    # Bypass check if no new keys were added
+    if not any(
+        getattr(key, "__lines__", None)
+        for changes in changed_rosdeps.values()
+        for key in changes.keys()
+    ):
+        return
+
+    recommendation = Recommendation.APPROVE
+    problems = set()
+
+    # Native packages are strongly preferred
+    for file, changes in changed_rosdeps.items():
+        for key, rules in changes.items():
+            if not getattr(key, "__lines__", None):
+                continue
+
+            is_pip = isinstance(rules, dict) and any(
+                isinstance(rule, dict) and "pip" in rule.keys()
+                for rule in rules.values()
+            )
+            if not is_pip:
+                continue
+
+            package_name = key.replace("-pip", "")
+            search_names = [package_name]
+            if package_name.startswith("python3-"):
+                search_names.append(package_name[8:])
+            elif not package_name.startswith("python-"):
+                search_names.append("python3-" + package_name)
+
+            found_any = False
+            found_urls = []
+            for name in set(search_names):
+                for platform in ["ubuntu", "debian"]:
+                    url = f"https://packages.{platform}.com/search?keywords={quote(name)}&searchon=names&suite=all&section=all"
+                    try:
+                        result = subprocess.run(
+                            ["curl", "-s", "-L", url],
+                            capture_output=True,
+                            text=True,
+                            timeout=10,
+                        )
+                        if (
+                            f"<h3>Package {name}</h3>" in result.stdout
+                            or f"Exact hits" in result.stdout
+                            or f'class="binpkg">{name}</a>' in result.stdout
+                        ):
+                            found_any = True
+                            found_urls.append(f"{platform}: {name}")
+                    except Exception as e:
+                        logger.error(f"Error checking {platform}: {e}")
+
+            if found_any:
+                recommendation = min(recommendation, Recommendation.NEUTRAL)
+                problems.add(
+                    f"Found native package(s) for `{key}`, prefer native over pip: "
+                    + ", ".join(found_urls)
+                )
+                annotations.append(
+                    Annotation(
+                        file,
+                        key.__lines__,
+                        f"Found native package(s) for `{key}`, prefer native over pip",
+                    )
+                )
+
+    if problems:
+        message = "\n- ".join(
+            [
+                "There are problems with native existence for new rosdep keys:",
+            ]
+            + sorted(problems)
+        )
+    else:
+        message = "No native Ubuntu/Debian packages found for new pip keys"
+
+    criteria.append(Criterion(recommendation, message))
+
+
 def _is_yaml_blob(item, depth) -> bool:
     return PurePosixPath(item.path).suffix == '.yaml'
 
@@ -432,5 +515,6 @@ class RosdepAnalyzer(ElementAnalyzerExtensionPoint):
         _check_platforms(criteria, annotations, changed_rosdeps)
         _check_installers(criteria, annotations, changed_rosdeps)
         _check_suitability(criteria, annotations, changed_rosdeps, key_counts)
+        _check_native_existence(criteria, annotations, changed_rosdeps)
 
         return criteria, annotations

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,7 @@ addfinalizer
 apache
 archlinux
 autouse
+backticks
 binpkg
 bubblify
 buildfarm

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,7 @@ addfinalizer
 apache
 archlinux
 autouse
+binpkg
 bubblify
 buildfarm
 colcon
@@ -61,6 +62,7 @@ rstrip
 rtype
 runpy
 scspell
+searchon
 setuptools
 thomas
 traceback
@@ -68,6 +70,7 @@ ubuntu
 unidiff
 unittest
 urllib
+urls
 utopic
 waldo
 whisky

--- a/test/test_rosdep_checks.py
+++ b/test/test_rosdep_checks.py
@@ -4,6 +4,8 @@
 import itertools
 from pathlib import Path
 from typing import Iterable
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from git import Repo
 import pytest
@@ -295,6 +297,46 @@ VIOLATIONS = {
         },
     },
 }
+
+
+@pytest.fixture(autouse=True)
+def mock_subprocess():
+    with patch('rosdistro_reviewer.element_analyzer.rosdep.subprocess.run') as mock_run:
+        mock_result = MagicMock()
+        mock_result.stdout = "No package found"
+        mock_run.return_value = mock_result
+        yield mock_run
+
+
+def test_native_existence_violation(rosdep_repo, mock_subprocess):
+    repo_dir = Path(rosdep_repo.working_tree_dir)
+    extension = RosdepAnalyzer()
+
+    # native-exists exists as native package
+    violation_rules = {
+        'python.yaml': {
+            'python3-native-exists-pip': {
+                '*': {
+                    'pip': {
+                        'packages': ['native-exists'],
+                    },
+                },
+            },
+        },
+    }
+    rules = _merge_two_rules(EXISTING_RULES, violation_rules)
+    for file_name, data in rules.items():
+        file_path = repo_dir / 'rosdep' / file_name
+        with file_path.open('w') as f:
+            yaml.dump(data, f)
+
+    # Override mock to simulate finding a native package for native-exists
+    mock_subprocess.return_value.stdout = "<h3>Package python3-native-exists</h3>"
+
+    criteria, annotations = extension.analyze(repo_dir)
+    assert criteria and annotations
+    assert any(Recommendation.APPROVE != c.recommendation for c in criteria)
+    assert any("Found native package(s) for `python3-native-exists-pip`" in c.rationale for c in criteria)
 
 
 def pytest_generate_tests(metafunc):

--- a/test/test_rosdep_checks.py
+++ b/test/test_rosdep_checks.py
@@ -301,9 +301,11 @@ VIOLATIONS = {
 
 @pytest.fixture(autouse=True)
 def mock_subprocess():
-    with patch('rosdistro_reviewer.element_analyzer.rosdep.subprocess.run') as mock_run:
+    with patch(
+        'rosdistro_reviewer.element_analyzer.rosdep.subprocess.run'
+    ) as mock_run:
         mock_result = MagicMock()
-        mock_result.stdout = "No package found"
+        mock_result.stdout = 'No package found'
         mock_run.return_value = mock_result
         yield mock_run
 
@@ -331,12 +333,16 @@ def test_native_existence_violation(rosdep_repo, mock_subprocess):
             yaml.dump(data, f)
 
     # Override mock to simulate finding a native package for native-exists
-    mock_subprocess.return_value.stdout = "<h3>Package python3-native-exists</h3>"
+    mock_subprocess.return_value.stdout = \
+        '<h3>Package python3-native-exists</h3>'
 
     criteria, annotations = extension.analyze(repo_dir)
     assert criteria and annotations
     assert any(Recommendation.APPROVE != c.recommendation for c in criteria)
-    assert any("Found native package(s) for `python3-native-exists-pip`" in c.rationale for c in criteria)
+    assert any(
+        'Found native package(s) for `python3-native-exists-pip`'
+        in c.rationale for c in criteria
+    )
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
This PR adds an automated check to verify if a proposed pip key in rosdep has a native Ubuntu or Debian counterpart. If a native package exists, it flags the PR to prefer native over pip.

Addresses #30 