### PR TITLE
feat: implement new package checks using ManifestCheck framework

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -37,6 +37,27 @@ class ManifestCheck:
         raise NotImplementedError()
 
 
+class REP144Check(ManifestCheck):
+    """Check if the package name follows REP-144."""
+
+    def check(self, pxml_path: str, pxml_content: str) -> List[str]:
+        name_match = re.search(r'<name>(.*?)</name>', pxml_content)
+        if name_match:
+            pkg_name = name_match.group(1)
+            if not _is_rep144_compliant(pkg_name):
+                return [f"Package '{pkg_name}' does not follow REP-144"]
+        return []
+
+
+class LicenseTagCheck(ManifestCheck):
+    """Check if the package has at least one license tag."""
+
+    def check(self, pxml_path: str, pxml_content: str) -> List[str]:
+        if not re.search(r'<license(>| .*?>)', pxml_content):
+            return ['Missing <license> tag in package.xml']
+        return []
+
+
 def _check_duplicates(criteria, annotations, index, entities):
     # Bypass check if no repo or package names were added/modified
     if not any(
@@ -148,6 +169,10 @@ def _prune_index(changed_distros):
             del changed_distros[distro_name]
 
 
+def _is_rep144_compliant(name: str) -> bool:
+    return bool(re.match(r'^[a-z][a-z0-9_]*$', name))
+
+
 def _is_any_modified(data: Any) -> bool:
     if getattr(data, '__lines__', None) is not None:
         return True
@@ -183,6 +208,9 @@ def _check_source_repositories(
     This function clones repositories that were modified or added,
     and runs a suite of checks on their contents.
     """
+    problems = set()
+    recommendation = Recommendation.APPROVE
+
     for distro_name, distro in (index or {}).items():
         for distro_file, repos in (distro or {}).items():
             for repo_name, repo in (repos or {}).items():
@@ -210,6 +238,26 @@ def _check_source_repositories(
                         check=True,
                     )
 
+                    # Check for LICENSE file
+                    has_license = False
+                    for f in os.listdir(temp_dir):
+                        if f.lower() in [
+                            'license', 'license.txt', 'license.md', 'copying'
+                        ]:
+                            has_license = True
+                            break
+                    if not has_license:
+                        recommendation = min(
+                            recommendation, Recommendation.NEUTRAL)
+                        problems.add(
+                            f"New repository '{repo_name}' is "
+                            'missing a LICENSE file')
+                        annotations.append(
+                            Annotation(
+                                distro_file, repo_name.__lines__,
+                                'Missing LICENSE file in source repo')
+                        )
+
                     # Run manifest-based checks
                     package_xmls_found = False
                     for root, _, files in os.walk(temp_dir):
@@ -223,24 +271,26 @@ def _check_source_repositories(
                                         errors = check.check(
                                             pxml_path, content)
                                         for err in (errors or []):
+                                            recommendation = min(
+                                                recommendation,
+                                                Recommendation.NEUTRAL)
+                                            problems.add(
+                                                f"{err} in '{repo_name}'")
                                             annotations.append(
                                                 Annotation(
                                                     distro_file,
                                                     repo_name.__lines__,
                                                     err))
-                                            criteria.append(
-                                                Criterion(
-                                                    Recommendation.NEUTRAL,
-                                                    f"{err} in '{repo_name}'"))
                             except Exception as e:
                                 logger.error(
                                     f'Error checking {pxml_path}: {e}')
 
                     if not package_xmls_found:
-                        criteria.append(
-                            Criterion(
-                                Recommendation.NEUTRAL,
-                                f"No ROS packages found in '{repo_name}'"))
+                        recommendation = min(
+                            recommendation, Recommendation.NEUTRAL)
+                        problems.add(
+                            f"New repository '{repo_name}' does not contain "
+                            'any ROS packages (missing package.xml)')
                         annotations.append(
                             Annotation(
                                 distro_file, repo_name.__lines__,
@@ -248,12 +298,22 @@ def _check_source_repositories(
 
                 except subprocess.SubprocessError as e:
                     logger.error(f'Error cloning {url}: {e}')
-                    criteria.append(
-                        Criterion(
-                            Recommendation.NEUTRAL,
-                            f"Could not clone repository '{repo_name}': {e}"))
+                    recommendation = min(
+                        recommendation, Recommendation.NEUTRAL)
+                    problems.add(
+                        f"Could not clone repository '{repo_name}': {e}")
                 finally:
                     shutil.rmtree(temp_dir)
+
+    if problems:
+        message = '\n- '.join(
+            ['There are problems with new package submissions:'] +
+            sorted(problems))
+    else:
+        message = 'New package submissions follow guidelines'
+
+    _validate_markdown(message)
+    criteria.append(Criterion(recommendation, message))
 
 
 class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):
@@ -304,5 +364,9 @@ class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):
         logger.info('Performing analysis on ROS distribution changes...')
 
         _check_duplicates(criteria, annotations, index, entities)
+        
+        _check_source_repositories(
+            criteria, annotations, index, 
+            [REP144Check(), LicenseTagCheck()])
 
         return criteria, annotations

--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -1,7 +1,12 @@
 # Copyright 2026 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+import os
 from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
 from typing import Any, Dict, List, Optional, Tuple
 
 from colcon_core.logging import colcon_logger
@@ -16,6 +21,20 @@ from rosdistro_reviewer.yaml_changes import prune_changed_yaml
 import yaml
 
 logger = colcon_logger.getChild(__name__)
+
+
+class ManifestCheck:
+    """Base class for checks performed on ROS package manifests."""
+
+    def check(self, pxml_path: str, pxml_content: str) -> List[str]:
+        """
+        Perform a check on a package manifest.
+
+        :param pxml_path: Path to the package.xml file
+        :param pxml_content: Content of the package.xml file
+        :return: A list of error messages, or an empty list if no issues found
+        """
+        raise NotImplementedError()
 
 
 def _check_duplicates(criteria, annotations, index, entities):
@@ -127,6 +146,114 @@ def _prune_index(changed_distros):
                 del distro[distro_file]
         if not distro:
             del changed_distros[distro_name]
+
+
+def _is_any_modified(data: Any) -> bool:
+    if getattr(data, '__lines__', None) is not None:
+        return True
+    if isinstance(data, dict):
+        for k, v in data.items():
+            if _is_any_modified(k) or _is_any_modified(v):
+                return True
+    elif isinstance(data, list):
+        for item in data:
+            if _is_any_modified(item):
+                return True
+    return False
+
+
+def _validate_markdown(content: str) -> None:
+    """Ensure generated markdown is structurally sound."""
+    # Check for balanced backticks
+    if len(re.findall(r'(?<!`)`(?!`)', content)) % 2 != 0:
+        raise ValueError('Unbalanced single backticks in markdown')
+    if len(re.findall(r'```', content)) % 2 != 0:
+        raise ValueError('Unbalanced triple backticks in markdown')
+
+
+def _check_source_repositories(
+    criteria: List[Criterion],
+    annotations: List[Annotation],
+    index: Dict[str, Any],
+    manifest_checks: List[ManifestCheck]
+) -> None:
+    """
+    Check source repositories for common issues.
+
+    This function clones repositories that were modified or added,
+    and runs a suite of checks on their contents.
+    """
+    for distro_name, distro in (index or {}).items():
+        for distro_file, repos in (distro or {}).items():
+            for repo_name, repo in (repos or {}).items():
+                source = repo.get('source')
+                if not source or source.get('type') != 'git':
+                    continue
+
+                if not _is_any_modified(repo_name) and \
+                   not _is_any_modified(repo):
+                    continue
+
+                url = source.get('url')
+                version = source.get('version', 'master')
+                if not url:
+                    continue
+
+                logger.info(f'Checking source repository: {url}')
+                temp_dir = tempfile.mkdtemp()
+                try:
+                    subprocess.run(
+                        ['git', 'clone', '--depth', '1', '-b',
+                         version, url, temp_dir],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                    )
+
+                    # Run manifest-based checks
+                    package_xmls_found = False
+                    for root, _, files in os.walk(temp_dir):
+                        if 'package.xml' in files:
+                            package_xmls_found = True
+                            pxml_path = os.path.join(root, 'package.xml')
+                            try:
+                                with open(pxml_path, 'r') as f:
+                                    content = f.read()
+                                    for check in manifest_checks:
+                                        errors = check.check(
+                                            pxml_path, content)
+                                        for err in (errors or []):
+                                            annotations.append(
+                                                Annotation(
+                                                    distro_file,
+                                                    repo_name.__lines__,
+                                                    err))
+                                            criteria.append(
+                                                Criterion(
+                                                    Recommendation.NEUTRAL,
+                                                    f"{err} in '{repo_name}'"))
+                            except Exception as e:
+                                logger.error(
+                                    f'Error checking {pxml_path}: {e}')
+
+                    if not package_xmls_found:
+                        criteria.append(
+                            Criterion(
+                                Recommendation.NEUTRAL,
+                                f"No ROS packages found in '{repo_name}'"))
+                        annotations.append(
+                            Annotation(
+                                distro_file, repo_name.__lines__,
+                                'No package.xml found in source repo'))
+
+                except subprocess.SubprocessError as e:
+                    logger.error(f'Error cloning {url}: {e}')
+                    criteria.append(
+                        Criterion(
+                            Recommendation.NEUTRAL,
+                            f"Could not clone repository '{repo_name}': {e}"))
+                finally:
+                    shutil.rmtree(temp_dir)
 
 
 class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):

--- a/test/test_rosdistro_checks.py
+++ b/test/test_rosdistro_checks.py
@@ -146,61 +146,58 @@ def mock_subprocess():
             if cmd[0] == 'git' and cmd[1] == 'clone':
                 dest = cmd[7]
                 os.makedirs(dest, exist_ok=True)
+                with open(os.path.join(dest, 'LICENSE'), 'w') as f:
+                    f.write('dummy license')
                 with open(os.path.join(dest, 'package.xml'), 'w') as f:
-                    f.write('<package><name>valid_package</name></package>')
+                    f.write('<package format="2"><name>valid_package</name>'
+                            '<version>1.0.0</version>'
+                            '<description>a</description>'
+                            '<maintainer email="a@a.a">a</maintainer>'
+                            '<license>Apache-2.0</license></package>')
             return MagicMock()
         mock_run.side_effect = default_side_effect
         yield mock_run
 
 
-def test_manifest_base_orchestration(rosdistro_index_repo, mock_subprocess):
-    from rosdistro_reviewer.element_analyzer.rosdistro import \
-        _check_source_repositories, ManifestCheck
-    from rosdistro_reviewer.review import Recommendation
-
-    class SimpleCheck(ManifestCheck):
-        def check(self, pxml_path, pxml_content):
-            if 'fail' in pxml_content:
-                return ['Found failure string']
-            return []
-
+def test_new_package_checks(rosdistro_index_repo, mock_subprocess):
     repo_dir = Path(rosdistro_index_repo.working_tree_dir)
-    
-    # Simulate a new repo
-    class AnnotatedStr(str): pass
-    repo_name = AnnotatedStr('new_repo')
-    repo_name.__lines__ = range(1, 2)
-    
-    index = {
+    extension = RosdistroAnalyzer()
+
+    # Case 1: Missing LICENSE and REP-144 violation
+    violation_rules = {
         'rolling': {
-            'rolling/distribution.yaml': {
-                repo_name: {
-                    'source': {
-                        'type': 'git',
-                        'url': 'https://example.com/new_repo.git',
-                        'version': 'main'
-                    }
-                }
-            }
-        }
+            'violation_repo': {
+                'source': {
+                    'type': 'git',
+                    'url': 'https://example.com/violation.git',
+                    'version': 'main',
+                },
+            },
+        },
     }
+    distros = _merge_distributions(EXISTING_DISTROS, violation_rules)
+    for distro_name, repos in distros.items():
+        file_path = repo_dir / distro_name / 'distribution.yaml'
+        with file_path.open('w') as f:
+            yaml.dump({'repositories': repos}, f)
 
-    criteria = []
-    annotations = []
-
-    # Mock git clone to provide a 'fail' manifest
     def side_effect(cmd, **kwargs):
         dest = cmd[7]
         os.makedirs(dest, exist_ok=True)
+        # Invalid name and NO license file
         with open(os.path.join(dest, 'package.xml'), 'w') as f:
-            f.write('<package>fail</package>')
+            f.write('<package format="2"><name>Invalid_Name</name>'
+                    '<version>1.0.0</version>'
+                    '<description>a</description>'
+                    '<maintainer email="a@a.a">a</maintainer>'
+                    '<license>Apache-2.0</license></package>')
         return MagicMock()
     mock_subprocess.side_effect = side_effect
 
-    _check_source_repositories(criteria, annotations, index, [SimpleCheck()])
-    
-    assert any('Found failure string' in c.rationale for c in criteria)
-    assert any(a.message == 'Found failure string' for a in annotations)
+    criteria, annotations = extension.analyze(repo_dir)
+    assert criteria and annotations
+    assert any("missing a LICENSE file" in c.rationale for c in criteria)
+    assert any("does not follow REP-144" in c.rationale for c in criteria)
 
 
 # This is a list of violations to check for.

--- a/test/test_rosdistro_checks.py
+++ b/test/test_rosdistro_checks.py
@@ -2,8 +2,11 @@
 # Licensed under the Apache License, Version 2.0
 
 import itertools
+import os
 from pathlib import Path
 from typing import Iterable
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from git import Repo
 import pytest
@@ -41,7 +44,7 @@ def rosdistro_index_repo(empty_repo) -> Iterable[Repo]:
         empty_repo.index.add(str(file_path))
 
     index_path = repo_dir / 'index-v4.yaml'
-    with index_path.open('w') as f:
+    with index_path.open('r' if index_path.exists() else 'w') as f:
         yaml.dump(_generate_index(EXISTING_DISTROS.keys()), f)
 
     empty_repo.index.add(str(index_path))
@@ -132,6 +135,72 @@ CONTROL_DISTROS = {
         },
     },
 }
+
+
+@pytest.fixture(autouse=True)
+def mock_subprocess():
+    with patch(
+        'rosdistro_reviewer.element_analyzer.rosdistro.subprocess.run'
+    ) as mock_run:
+        def default_side_effect(cmd, **kwargs):
+            if cmd[0] == 'git' and cmd[1] == 'clone':
+                dest = cmd[7]
+                os.makedirs(dest, exist_ok=True)
+                with open(os.path.join(dest, 'package.xml'), 'w') as f:
+                    f.write('<package><name>valid_package</name></package>')
+            return MagicMock()
+        mock_run.side_effect = default_side_effect
+        yield mock_run
+
+
+def test_manifest_base_orchestration(rosdistro_index_repo, mock_subprocess):
+    from rosdistro_reviewer.element_analyzer.rosdistro import \
+        _check_source_repositories, ManifestCheck
+    from rosdistro_reviewer.review import Recommendation
+
+    class SimpleCheck(ManifestCheck):
+        def check(self, pxml_path, pxml_content):
+            if 'fail' in pxml_content:
+                return ['Found failure string']
+            return []
+
+    repo_dir = Path(rosdistro_index_repo.working_tree_dir)
+    
+    # Simulate a new repo
+    class AnnotatedStr(str): pass
+    repo_name = AnnotatedStr('new_repo')
+    repo_name.__lines__ = range(1, 2)
+    
+    index = {
+        'rolling': {
+            'rolling/distribution.yaml': {
+                repo_name: {
+                    'source': {
+                        'type': 'git',
+                        'url': 'https://example.com/new_repo.git',
+                        'version': 'main'
+                    }
+                }
+            }
+        }
+    }
+
+    criteria = []
+    annotations = []
+
+    # Mock git clone to provide a 'fail' manifest
+    def side_effect(cmd, **kwargs):
+        dest = cmd[7]
+        os.makedirs(dest, exist_ok=True)
+        with open(os.path.join(dest, 'package.xml'), 'w') as f:
+            f.write('<package>fail</package>')
+        return MagicMock()
+    mock_subprocess.side_effect = side_effect
+
+    _check_source_repositories(criteria, annotations, index, [SimpleCheck()])
+    
+    assert any('Found failure string' in c.rationale for c in criteria)
+    assert any(a.message == 'Found failure string' for a in annotations)
 
 
 # This is a list of violations to check for.


### PR DESCRIPTION
This PR implements the LICENSE presence and REP-144 naming checks for new package submissions using the new ManifestCheck base framework. This refactoring makes it easy to add more automated manifest validations in the future.