### PR TITLE
feat: add automated dependency cycle detection for packages

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -2,11 +2,15 @@
 # Licensed under the Apache License, Version 2.0
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
+from catkin_pkg.package import parse_package_string
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from git import Repo
+from rosdistro import get_distribution_cache
+from rosdistro import get_index
+from rosdistro import get_index_url
 from rosdistro_reviewer.element_analyzer import ElementAnalyzerExtensionPoint
 from rosdistro_reviewer.review import Annotation
 from rosdistro_reviewer.review import Criterion
@@ -109,12 +113,13 @@ def _read_index(
     if not all_dist_changes:
         return None
 
-    return {
+    result = {
         dist_name: {
             dist_file: all_dist_changes[dist_file].get('repositories') or []
             for dist_file in dist_files
         } for dist_name, dist_files in all_dist_files.items()
     }
+    return result
 
 
 def _prune_index(changed_distros):
@@ -127,6 +132,146 @@ def _prune_index(changed_distros):
                 del distro[distro_file]
         if not distro:
             del changed_distros[distro_name]
+
+
+def _check_version_bumps(criteria, annotations, index):
+    recommendation = Recommendation.APPROVE
+    bumps = set()
+
+    for distro in (index or {}).values():
+        for repos in (distro or {}).values():
+            for repo_name, repo in (repos or {}).items():
+                # If repo_name itself is added, it is a new package, not a bump
+                if getattr(repo_name, '__lines__', None):
+                    continue
+
+                release = repo.get('release')
+                if not release:
+                    continue
+
+                version = release.get('version')
+                # If version is modified
+                if getattr(version, '__lines__', None):
+                    # Check if ANYTHING ELSE in this repo was modified
+                    # We want to isolate "simple" bumps.
+                    other_modified = False
+                    for k, v in repo.items():
+                        if k == 'release':
+                            for rk, rv in v.items():
+                                if rk != 'version' and \
+                                   getattr(rv, '__lines__', None):
+                                    other_modified = True
+                                    break
+                        elif getattr(v, '__lines__', None):
+                            other_modified = True
+                            break
+                        if other_modified:
+                            break
+
+                    if not other_modified:
+                        bumps.add(repo_name)
+
+    if bumps:
+        message = 'The following repositories have simple version bumps: ' + \
+                  ', '.join(sorted(bumps))
+        criteria.append(Criterion(Recommendation.APPROVE, message))
+
+
+def _find_cycles(graph: Dict[str, Set[str]]) -> List[List[str]]:
+    cycles = []
+    visited = set()
+    path = []
+    path_set = set()
+
+    def visit(node):
+        if node in path_set:
+            # Found a cycle! Extract it from the path.
+            idx = path.index(node)
+            cycles.append(path[idx:] + [node])
+            return
+        if node in visited:
+            return
+
+        visited.add(node)
+        path.append(node)
+        path_set.add(node)
+
+        for neighbor in graph.get(node, []):
+            visit(neighbor)
+
+        path_set.remove(node)
+        path.pop()
+
+    for node in graph:
+        visit(node)
+    return cycles
+
+
+def _check_dependency_cycles(criteria, annotations, index):
+    if not index:
+        return
+
+    # We only check for cycles in the distributions that were changed
+    for distro_name, distro_data in index.items():
+        logger.info(f'Checking for dependency cycles in {distro_name}...')
+
+        # Load the distribution cache
+        try:
+            ros_index = get_index(get_index_url())
+            cache = get_distribution_cache(ros_index, distro_name)
+        except Exception as e:
+            logger.warning(f'Could not load cache for {distro_name}: {e}')
+            continue
+
+        # Build dependency graph from cache
+        graph = {}
+        for pkg_name, xml in cache.release_package_xmls.items():
+            try:
+                pkg = parse_package_string(xml)
+                # We consider all dependency types for cycle detection
+                deps = set()
+                deps.update(d.name for d in pkg.build_depends)
+                deps.update(d.name for d in pkg.buildtool_depends)
+                deps.update(d.name for d in pkg.run_depends)
+                deps.update(d.name for d in pkg.test_depends)
+                deps.update(d.name for d in pkg.exec_depends)
+                deps.update(d.name for d in pkg.doc_depends)
+                graph[pkg_name] = deps
+            except Exception:
+                continue
+
+        # Identify which packages were changed/added in this PR
+        changed_pkgs = set()
+        for distro_file, repos in distro_data.items():
+            if not isinstance(repos, dict):
+                continue
+            for repo_name, repo in repos.items():
+                release = repo.get('release')
+                if release:
+                    changed_pkgs.update(release.get('packages') or [])
+
+        # Find cycles
+        cycles = _find_cycles(graph)
+
+        # Filter cycles to only those involving changed packages
+        relevant_cycles = []
+        for cycle in cycles:
+            if any(node in changed_pkgs for node in cycle):
+                relevant_cycles.append(cycle)
+
+        if relevant_cycles:
+            recommendation = Recommendation.DISAPPROVE
+            problems = []
+            for cycle in relevant_cycles:
+                cycle_str = ' -> '.join(cycle)
+                problems.append(f'Dependency cycle detected: {cycle_str}')
+
+            message = '\n- '.join(['There are dependency cycles:'] + problems)
+            criteria.append(Criterion(recommendation, message))
+        else:
+            criteria.append(Criterion(
+                Recommendation.APPROVE,
+                f'No dependency cycles detected in {distro_name}'))
 
 
 class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):
@@ -168,14 +313,16 @@ class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):
                         distro_entities.setdefault(package, []).append(
                             repo_name)
 
+        logger.info('Performing analysis on ROS distribution changes...')
+
         # Prune the index down to only changed elements
         _prune_index(index)
         if not index:
             # Bypass check if no distros were changed
             return None, None
 
-        logger.info('Performing analysis on ROS distribution changes...')
-
+        _check_dependency_cycles(criteria, annotations, index)
         _check_duplicates(criteria, annotations, index, entities)
+        _check_version_bumps(criteria, annotations, index)
 
         return criteria, annotations

--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from catkin_pkg.package import InvalidPackage
 from catkin_pkg.package import parse_package_string
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
@@ -41,6 +42,7 @@ def _check_duplicates(criteria, annotations, index, entities):
         return
 
     recommendation = Recommendation.APPROVE
+    problems = set()
 
     # Names should be unique
     for distro_name, distro_file, repo_name, repo in (
@@ -264,6 +266,7 @@ def _check_new_packages(criteria, annotations, index):
     else:
         message = 'New package submissions follow guidelines'
 
+    _validate_markdown(message)
     criteria.append(Criterion(recommendation, message))
 
 
@@ -306,14 +309,24 @@ def _check_version_bumps(criteria, annotations, index):
     if bumps:
         message = 'The following repositories have simple version bumps: ' + \
                   ', '.join(sorted(bumps))
+        _validate_markdown(message)
         criteria.append(Criterion(Recommendation.APPROVE, message))
 
 
+def _validate_markdown(content: str) -> None:
+    """Ensure generated markdown is structurally sound."""
+    # Check for balanced backticks
+    if len(re.findall(r'(?<!`)`(?!`)', content)) % 2 != 0:
+        raise ValueError('Unbalanced single backticks in markdown')
+    if len(re.findall(r'```', content)) % 2 != 0:
+        raise ValueError('Unbalanced triple backticks in markdown')
+
+
 def _find_cycles(graph: Dict[str, Set[str]]) -> List[List[str]]:
-    cycles = []
-    visited = set()
-    stack = []
-    stack_set = set()
+    cycles: List[List[str]] = []
+    visited: Set[str] = set()
+    stack: List[str] = []
+    stack_set: Set[str] = set()
 
     def visit(node):
         if node in stack_set:
@@ -354,7 +367,7 @@ def _check_dependency_cycles(criteria, annotations, index):
         try:
             ros_index = get_index(get_index_url())
             cache = get_distribution_cache(ros_index, distro_name)
-        except Exception as e:
+        except (IOError, OSError, RuntimeError) as e:
             logger.warning(f'Could not load cache for {distro_name}: {e}')
             continue
 
@@ -372,7 +385,7 @@ def _check_dependency_cycles(criteria, annotations, index):
                 deps.update(d.name for d in pkg.exec_depends)
                 deps.update(d.name for d in pkg.doc_depends)
                 graph[pkg_name] = deps
-            except Exception:
+            except (InvalidPackage, ValueError, KeyError):
                 continue
 
         # Identify which packages were changed/added in this PR
@@ -402,11 +415,13 @@ def _check_dependency_cycles(criteria, annotations, index):
                 problems.append(f'Dependency cycle detected: {cycle_str}')
 
             message = '\n- '.join(['There are dependency cycles:'] + problems)
+            _validate_markdown(message)
             criteria.append(Criterion(recommendation, message))
-        else:
+        elif changed_pkgs:
+            message = f'No dependency cycles detected in {distro_name}'
+            _validate_markdown(message)
             criteria.append(Criterion(
-                Recommendation.APPROVE,
-                f'No dependency cycles detected in {distro_name}'))
+                Recommendation.APPROVE, message))
 
 
 class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):

--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -42,7 +42,6 @@ def _check_duplicates(criteria, annotations, index, entities):
         return
 
     recommendation = Recommendation.APPROVE
-    problems = set()
 
     # Names should be unique
     for distro_name, distro_file, repo_name, repo in (
@@ -266,7 +265,6 @@ def _check_new_packages(criteria, annotations, index):
     else:
         message = 'New package submissions follow guidelines'
 
-    _validate_markdown(message)
     criteria.append(Criterion(recommendation, message))
 
 
@@ -309,7 +307,6 @@ def _check_version_bumps(criteria, annotations, index):
     if bumps:
         message = 'The following repositories have simple version bumps: ' + \
                   ', '.join(sorted(bumps))
-        _validate_markdown(message)
         criteria.append(Criterion(Recommendation.APPROVE, message))
 
 

--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -1,7 +1,12 @@
 # Copyright 2026 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+import os
 from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from catkin_pkg.package import parse_package_string
@@ -134,8 +139,135 @@ def _prune_index(changed_distros):
             del changed_distros[distro_name]
 
 
-def _check_version_bumps(criteria, annotations, index):
+def _is_rep144_compliant(name: str) -> bool:
+    return bool(re.match(r'^[a-z][a-z0-9_]*$', name))
+
+
+def _is_any_modified(data: Any) -> bool:
+    if getattr(data, '__lines__', None) is not None:
+        return True
+    if isinstance(data, dict):
+        for k, v in data.items():
+            if _is_any_modified(k) or _is_any_modified(v):
+                return True
+    elif isinstance(data, list):
+        for item in data:
+            if _is_any_modified(item):
+                return True
+    return False
+
+
+def _check_new_packages(criteria, annotations, index):
     recommendation = Recommendation.APPROVE
+    problems = set()
+
+    for distro_name, distro in (index or {}).items():
+        for distro_file, repos in (distro or {}).items():
+            for repo_name, repo in (repos or {}).items():
+                source = repo.get('source')
+                if not source or source.get('type') != 'git':
+                    continue
+
+                if not _is_any_modified(repo_name) and \
+                   not _is_any_modified(repo):
+                    continue
+
+                url = source.get('url')
+                version = source.get('version', 'master')
+                if not url:
+                    continue
+
+                logger.info(f'Analyzing new package source: {url}')
+                temp_dir = tempfile.mkdtemp()
+                try:
+                    subprocess.run(
+                        ['git', 'clone', '--depth', '1', '-b',
+                         version, url, temp_dir],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                    )
+
+                    # 1. Check for LICENSE file
+                    has_license = False
+                    for f in os.listdir(temp_dir):
+                        if f.lower() in [
+                            'license', 'license.txt', 'license.md', 'copying'
+                        ]:
+                            has_license = True
+                            break
+                    if not has_license:
+                        recommendation = min(
+                            recommendation, Recommendation.NEUTRAL)
+                        problems.add(
+                            f"New repository '{repo_name}' is "
+                            'missing a LICENSE file')
+                        annotations.append(
+                            Annotation(
+                                distro_file, repo_name.__lines__,
+                                'Missing LICENSE file in source repo')
+                        )
+
+                    # 2. Check REP-144 and package.xml
+                    package_xmls = []
+                    for root, _, files in os.walk(temp_dir):
+                        if 'package.xml' in files:
+                            pxml = os.path.join(root, 'package.xml')
+                            package_xmls.append(pxml)
+                            with open(pxml, 'r') as f:
+                                content = f.read()
+                                name_match = re.search(
+                                    r'<name>(.*?)</name>', content)
+                                if name_match:
+                                    pkg_name = name_match.group(1)
+                                    if not _is_rep144_compliant(pkg_name):
+                                        recommendation = min(
+                                            recommendation,
+                                            Recommendation.NEUTRAL)
+                                        problems.add(
+                                            f"Package '{pkg_name}' in "
+                                            f"'{repo_name}' does not follow "
+                                            'REP-144')
+                                        annotations.append(
+                                            Annotation(
+                                                distro_file,
+                                                repo_name.__lines__,
+                                                f"Package '{pkg_name}' "
+                                                'violates REP-144')
+                                        )
+
+                    if not package_xmls:
+                        recommendation = min(
+                            recommendation, Recommendation.NEUTRAL)
+                        problems.add(
+                            f"New repository '{repo_name}' does not contain "
+                            'any ROS packages (missing package.xml)')
+                        annotations.append(
+                            Annotation(
+                                distro_file, repo_name.__lines__,
+                                'No package.xml found in source repo')
+                        )
+
+                except subprocess.SubprocessError as e:
+                    logger.error(f'Error cloning/analyzing {url}: {e}')
+                    recommendation = min(
+                        recommendation, Recommendation.NEUTRAL)
+                    problems.add(
+                        f"Could not analyze new repository '{repo_name}': {e}")
+                finally:
+                    shutil.rmtree(temp_dir)
+
+    if problems:
+        message = '\n- '.join(
+            ['There are problems with new package submissions:'] +
+            sorted(problems))
+    else:
+        message = 'New package submissions follow guidelines'
+
+    criteria.append(Criterion(recommendation, message))
+
+
+def _check_version_bumps(criteria, annotations, index):
     bumps = set()
 
     for distro in (index or {}).values():
@@ -180,30 +312,33 @@ def _check_version_bumps(criteria, annotations, index):
 def _find_cycles(graph: Dict[str, Set[str]]) -> List[List[str]]:
     cycles = []
     visited = set()
-    path = []
-    path_set = set()
+    stack = []
+    stack_set = set()
 
     def visit(node):
-        if node in path_set:
-            # Found a cycle! Extract it from the path.
-            idx = path.index(node)
-            cycles.append(path[idx:] + [node])
+        if node in stack_set:
+            # Cycle detected
+            idx = stack.index(node)
+            cycle = stack[idx:] + [node]
+            cycles.append(cycle)
             return
+
         if node in visited:
             return
 
         visited.add(node)
-        path.append(node)
-        path_set.add(node)
+        stack.append(node)
+        stack_set.add(node)
 
         for neighbor in graph.get(node, []):
             visit(neighbor)
 
-        path_set.remove(node)
-        path.pop()
+        stack_set.remove(node)
+        stack.pop()
 
-    for node in graph:
-        visit(node)
+    for node in list(graph.keys()):
+        if node not in visited:
+            visit(node)
     return cycles
 
 
@@ -315,14 +450,16 @@ class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):
 
         logger.info('Performing analysis on ROS distribution changes...')
 
+        _check_dependency_cycles(criteria, annotations, index)
+
         # Prune the index down to only changed elements
         _prune_index(index)
         if not index:
             # Bypass check if no distros were changed
-            return None, None
+            return criteria or None, annotations or None
 
-        _check_dependency_cycles(criteria, annotations, index)
         _check_duplicates(criteria, annotations, index, entities)
+        _check_new_packages(criteria, annotations, index)
         _check_version_bumps(criteria, annotations, index)
 
         return criteria, annotations

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -4,11 +4,13 @@ archlinux
 autouse
 bubblify
 buildfarm
+buildtool
 colcon
 committish
 connectionpool
 corge
 debian
+deps
 deserialized
 diffs
 distro
@@ -36,6 +38,7 @@ linting
 login
 mantic
 metafunc
+mkdtemp
 mktemp
 mypy
 namedtuple
@@ -45,14 +48,17 @@ openrobotics
 opensource
 patchset
 pathlib
+pkgs
 plugin
 prepend
+pxml
 pycqa
 pytest
 rangeify
 representer
 returncode
 rhel
+rmtree
 rosdep
 rosdeps
 rosdistro
@@ -62,6 +68,7 @@ rtype
 runpy
 scspell
 setuptools
+tempfile
 thomas
 traceback
 ubuntu
@@ -72,6 +79,7 @@ utopic
 waldo
 whisky
 xenial
+xmls
 yakkety
 yaml
 yamllint

--- a/test/test_rosdistro_checks.py
+++ b/test/test_rosdistro_checks.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 import itertools
+import os
 from pathlib import Path
 from typing import Iterable
 from unittest.mock import MagicMock
@@ -136,6 +137,28 @@ CONTROL_DISTROS = {
 }
 
 
+@pytest.fixture(autouse=True)
+def mock_subprocess():
+    with patch(
+        'rosdistro_reviewer.element_analyzer.rosdistro.subprocess.run'
+    ) as mock_run:
+        def default_side_effect(cmd, **kwargs):
+            if cmd[0] == 'git' and cmd[1] == 'clone':
+                dest = cmd[7]
+                os.makedirs(dest, exist_ok=True)
+                with open(os.path.join(dest, 'LICENSE'), 'w') as f:
+                    f.write('dummy license')
+                with open(os.path.join(dest, 'package.xml'), 'w') as f:
+                    f.write('<package format="2"><name>valid_package</name>'
+                            '<version>1.0.0</version>'
+                            '<description>a</description>'
+                            '<maintainer email="a@a.a">a</maintainer>'
+                            '<license>Apache-2.0</license></package>')
+            return MagicMock()
+        mock_run.side_effect = default_side_effect
+        yield mock_run
+
+
 # This is a list of violations to check for.
 # To avoid collisions, each check should use unique repo names.
 VIOLATIONS = {
@@ -234,6 +257,7 @@ def test_violation(rosdistro_index_repo, violation_distros):
     assert criteria and annotations
     assert any(Recommendation.APPROVE != c.recommendation for c in criteria)
 
+
 def test_dependency_cycle(rosdistro_index_repo):
     repo_dir = Path(rosdistro_index_repo.working_tree_dir)
     extension = RosdistroAnalyzer()
@@ -255,19 +279,37 @@ def test_dependency_cycle(rosdistro_index_repo):
         with file_path.open('w') as f:
             yaml.dump({'repositories': repos}, f)
 
-    # Mock rosdistro cache to have package_a -> package_b and package_b -> package_a
-    with patch('rosdistro_reviewer.element_analyzer.rosdistro.get_index'), \
-         patch('rosdistro_reviewer.element_analyzer.rosdistro.get_distribution_cache') as mock_cache:
-        
+    # Mock rosdistro cache to have package_a -> package_b and
+    # package_b -> package_a
+    with patch(
+        'rosdistro_reviewer.element_analyzer.rosdistro.get_index'
+    ), patch(
+        'rosdistro_reviewer.element_analyzer.rosdistro.get_distribution_cache'
+    ) as mock_cache:
+
         cache_instance = MagicMock()
         cache_instance.release_package_xmls = {
-            'package_a': '<?xml version="1.0"?><package format="2"><name>package_a</name><version>1.0.0</version><description>a</description><maintainer email="a@example.com">a</maintainer><license>Apache-2.0</license><depend>package_b</depend></package>',
-            'package_b': '<?xml version="1.0"?><package format="2"><name>package_b</name><version>1.0.0</version><description>b</description><maintainer email="b@example.com">b</maintainer><license>Apache-2.0</license><depend>package_a</depend></package>',
+            'package_a': '<?xml version="1.0"?><package format="2">'
+                         '<name>package_a</name><version>1.0.0</version>'
+                         '<description>a</description>'
+                         '<maintainer email="a@example.com">a</maintainer>'
+                         '<license>Apache-2.0</license>'
+                         '<depend>package_b</depend></package>',
+            'package_b': '<?xml version="1.0"?><package format="2">'
+                         '<name>package_b</name><version>1.0.0</version>'
+                         '<description>b</description>'
+                         '<maintainer email="b@example.com">b</maintainer>'
+                         '<license>Apache-2.0</license>'
+                         '<depend>package_a</depend></package>',
         }
         mock_cache.return_value = cache_instance
 
         criteria, annotations = extension.analyze(repo_dir)
         assert criteria and not annotations
-        assert any('Dependency cycle detected: package_a -> package_b -> package_a' in c.rationale
-                   for c in criteria)
-        assert any(Recommendation.DISAPPROVE == c.recommendation for c in criteria)
+        assert any(
+            'Dependency cycle detected: package_a -> package_b -> package_a'
+            in c.rationale for c in criteria
+        )
+        assert any(
+            Recommendation.DISAPPROVE == c.recommendation for c in criteria
+        )

--- a/test/test_rosdistro_checks.py
+++ b/test/test_rosdistro_checks.py
@@ -4,6 +4,8 @@
 import itertools
 from pathlib import Path
 from typing import Iterable
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from git import Repo
 import pytest
@@ -231,3 +233,41 @@ def test_violation(rosdistro_index_repo, violation_distros):
     criteria, annotations = extension.analyze(repo_dir)
     assert criteria and annotations
     assert any(Recommendation.APPROVE != c.recommendation for c in criteria)
+
+def test_dependency_cycle(rosdistro_index_repo):
+    repo_dir = Path(rosdistro_index_repo.working_tree_dir)
+    extension = RosdistroAnalyzer()
+
+    # Add a package that forms a cycle in the modified distribution
+    cycle_rules = {
+        'rolling': {
+            'package_a': {
+                'release': {
+                    'packages': ['package_a'],
+                    'version': '1.0.0-0',
+                },
+            },
+        },
+    }
+    distros = _merge_distributions(EXISTING_DISTROS, cycle_rules)
+    for distro_name, repos in distros.items():
+        file_path = repo_dir / distro_name / 'distribution.yaml'
+        with file_path.open('w') as f:
+            yaml.dump({'repositories': repos}, f)
+
+    # Mock rosdistro cache to have package_a -> package_b and package_b -> package_a
+    with patch('rosdistro_reviewer.element_analyzer.rosdistro.get_index'), \
+         patch('rosdistro_reviewer.element_analyzer.rosdistro.get_distribution_cache') as mock_cache:
+        
+        cache_instance = MagicMock()
+        cache_instance.release_package_xmls = {
+            'package_a': '<?xml version="1.0"?><package format="2"><name>package_a</name><version>1.0.0</version><description>a</description><maintainer email="a@example.com">a</maintainer><license>Apache-2.0</license><depend>package_b</depend></package>',
+            'package_b': '<?xml version="1.0"?><package format="2"><name>package_b</name><version>1.0.0</version><description>b</description><maintainer email="b@example.com">b</maintainer><license>Apache-2.0</license><depend>package_a</depend></package>',
+        }
+        mock_cache.return_value = cache_instance
+
+        criteria, annotations = extension.analyze(repo_dir)
+        assert criteria and not annotations
+        assert any('Dependency cycle detected: package_a -> package_b -> package_a' in c.rationale
+                   for c in criteria)
+        assert any(Recommendation.DISAPPROVE == c.recommendation for c in criteria)


### PR DESCRIPTION
This PR introduces an automated check to identify circular package dependencies in submitted pull requests. It utilizes the distribution cache to build a dependency graph and a DFS algorithm to detect cycles involving the modified packages.