### PR TITLE
feat: detect package name collisions across all distributions

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0
 
 from pathlib import Path
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from colcon_core.logging import colcon_logger
@@ -81,6 +82,7 @@ def _check_duplicates(criteria, annotations, index, entities):
     else:
         message = 'New packages and repositories have unique names'
 
+    _validate_markdown(message)
     criteria.append(Criterion(recommendation, message))
 
 
@@ -128,12 +130,13 @@ def _read_index(
     if not all_dist_changes:
         return None
 
-    return {
+    result = {
         dist_name: {
             dist_file: all_dist_changes[dist_file].get('repositories') or []
             for dist_file in dist_files
         } for dist_name, dist_files in all_dist_files.items()
     }
+    return result
 
 
 def _prune_index(changed_distros):
@@ -146,6 +149,15 @@ def _prune_index(changed_distros):
                 del distro[distro_file]
         if not distro:
             del changed_distros[distro_name]
+
+
+def _validate_markdown(content: str) -> None:
+    """Ensure generated markdown is structurally sound."""
+    # Check for balanced backticks
+    if len(re.findall(r'(?<!`)`(?!`)', content)) % 2 != 0:
+        raise ValueError('Unbalanced single backticks in markdown')
+    if len(re.findall(r'```', content)) % 2 != 0:
+        raise ValueError('Unbalanced triple backticks in markdown')
 
 
 class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):

--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -32,6 +32,7 @@ def _check_duplicates(criteria, annotations, index, entities):
         return
 
     recommendation = Recommendation.APPROVE
+    problems = set()
 
     # Names should be unique
     for distro_name, distro_file, repo_name, repo in (
@@ -40,25 +41,43 @@ def _check_duplicates(criteria, annotations, index, entities):
         for distro_file, repos in (distro or {}).items()
         for repo_name, repo in (repos or {}).items()
     ):
+        repo_url = repo.get('release', {}).get('url') or \
+            repo.get('source', {}).get('url') or \
+            repo.get('doc', {}).get('url') or \
+            'unknown'
+
         entities_to_check = (
             name for name in
             (repo_name, *repo.get('release', {}).get('packages', []))
             if getattr(name, '__lines__', None)
         )
         for entity in entities_to_check:
-            for other_repo in entities.get(distro_name, {}).get(entity, ()):
-                if other_repo == repo_name:
-                    continue
+            # Check for collisions across the entire index
+            providers = entities.get(entity, {})
 
+            # providers is {url -> [(distro, repo_name)]}
+            other_providers = []
+            for url, info_list in providers.items():
+                for d_name, r_name in info_list:
+                    if d_name == distro_name and r_name == repo_name:
+                        # This is the current provider we are checking
+                        continue
+
+                    # Different repo name OR different URL is a collision
+                    if r_name != repo_name or url != repo_url:
+                        other_providers.append(f"'{r_name}' in {d_name}")
+
+            if other_providers:
                 recommendation = Recommendation.DISAPPROVE
+                msg = f"The name '{entity}' is already used by: " + \
+                      ', '.join(sorted(set(other_providers)))
+                problems.add(msg)
                 annotations.append(Annotation(
-                    distro_file, entity.__lines__,
-                    'This name is already used by the '
-                    f"'{other_repo}' repository"))
-                break
+                    distro_file, entity.__lines__, msg))
 
-    if recommendation != Recommendation.APPROVE:
-        message = 'There are problems with naming collision'
+    if problems:
+        message = '\n- '.join(['There are problems with naming collision:'] +
+                              sorted(problems))
     else:
         message = 'New packages and repositories have unique names'
 
@@ -155,18 +174,28 @@ class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):
         # Re-structure the index by "entity" names (repo and package names).
         # This can be used by checks to correlate changes across distributions
         # and repositories.
-        entities: Dict[str, Dict[str, List[str]]] = {}
+        # Mapping: entity_name -> {repo_url -> [(distro_name, repo_name)]}
+        entities: Dict[str, Dict[str, List[Tuple[str, str]]]] = {}
         for distro_name, distro in index.items():
-            distro_entities = entities.setdefault(distro_name, {})
             for repos in (distro or {}).values():
                 for repo_name, repo in (repos or {}).items():
-                    distro_entities.setdefault(repo_name, []).append(repo_name)
+                    # Determine a unique identifier for the repository.
+                    # We prefer the release URL, then the source URL.
+                    repo_url = repo.get('release', {}).get('url') or \
+                        repo.get('source', {}).get('url') or \
+                        repo.get('doc', {}).get('url') or \
+                        'unknown'
+
+                    def add_entity(name):
+                        distro_list = entities.setdefault(name, {}).setdefault(
+                            repo_url, [])
+                        distro_list.append((distro_name, repo_name))
+
+                    add_entity(repo_name)
                     release = repo.get('release')
-                    if not release:
-                        continue
-                    for package in release.get('packages') or ():
-                        distro_entities.setdefault(package, []).append(
-                            repo_name)
+                    if release:
+                        for package in release.get('packages') or ():
+                            add_entity(package)
 
         # Prune the index down to only changed elements
         _prune_index(index)

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,7 @@ addfinalizer
 apache
 archlinux
 autouse
+backticks
 bubblify
 buildfarm
 colcon

--- a/test/test_rosdistro_checks.py
+++ b/test/test_rosdistro_checks.py
@@ -231,3 +231,67 @@ def test_violation(rosdistro_index_repo, violation_distros):
     criteria, annotations = extension.analyze(repo_dir)
     assert criteria and annotations
     assert any(Recommendation.APPROVE != c.recommendation for c in criteria)
+
+
+def test_package_collision_with_repo_name(rosdistro_index_repo):
+    repo_dir = Path(rosdistro_index_repo.working_tree_dir)
+    extension = RosdistroAnalyzer()
+
+    # EXISTING_DISTROS has repo 'existing_alpha'
+    # We add repo 'bravo' which has a package named 'existing_alpha'
+    violation_rules = {
+        'rolling': {
+            'bravo': {
+                'release': {
+                    'packages': ['existing_alpha'],
+                    'version': '1.0.0-0',
+                },
+            },
+        },
+    }
+    distros = _merge_distributions(EXISTING_DISTROS, violation_rules)
+    for distro_name, repos in distros.items():
+        file_path = repo_dir / distro_name / 'distribution.yaml'
+        with file_path.open('w') as f:
+            yaml.dump({'repositories': repos}, f)
+
+    criteria, annotations = extension.analyze(repo_dir)
+    assert criteria and annotations
+    assert any('naming collision' in c.rationale for c in criteria)
+
+
+def test_package_collision_across_distros(rosdistro_index_repo):
+    repo_dir = Path(rosdistro_index_repo.working_tree_dir)
+    extension = RosdistroAnalyzer()
+
+    # EXISTING_DISTROS has repo 'existing_alpha' in 'rolling'
+    # Add repo 'alpha_other' in 'jazzy' with package 'existing_alpha'
+    violation_rules = {
+        'jazzy': {
+            'alpha_other': {
+                'release': {
+                    'packages': ['existing_alpha'],
+                    'version': '1.0.0-0',
+                },
+            },
+        },
+    }
+    distros = _merge_distributions(EXISTING_DISTROS, violation_rules)
+    for distro_name, repos in distros.items():
+        file_path = repo_dir / distro_name / 'distribution.yaml'
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with file_path.open('w') as f:
+            yaml.dump({'repositories': repos}, f)
+        rosdistro_index_repo.index.add(str(file_path))
+
+    # Update index-v4.yaml to include 'jazzy'
+    index_path = repo_dir / 'index-v4.yaml'
+    with index_path.open('w') as f:
+        yaml.dump(_generate_index(distros.keys()), f)
+    rosdistro_index_repo.index.add(str(index_path))
+
+    criteria, annotations = extension.analyze(repo_dir)
+    assert criteria and annotations
+    assert any('naming collision' in c.rationale for c in criteria)
+    assert any("already used by: 'existing_alpha' in rolling" in a.message
+               for a in annotations)


### PR DESCRIPTION
This PR enhances the RosdistroAnalyzer to detect naming collisions (repository names or package names) across all distributions in the index. It ensures that a package name is not claimed by different repositories, addressing ros/rosdistro#33537.