### PR TITLE
Check package names against REP 144 mandatory rules

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -84,6 +84,82 @@ def _check_duplicates(criteria, annotations, index, entities):
     criteria.append(Criterion(recommendation, message))
 
 
+def _check_package_names(criteria, annotations, index):
+    # Bypass check if no packages were added/modified, and no release stanzas
+    # were added/modified which might use the repository name as a package
+    # name.
+    if not any(
+        any(getattr(package, '__lines__', None)
+            for package in repo.get('release', {}).get('packages') or ()) or
+        ((getattr(repo.get('release'), '__lines__', None) or
+          getattr(repo_name, '__lines__', None)) and
+         'release' in repo and not repo['release'].get('packages'))
+        for distro in (index or {}).values()
+        for repos in (distro or {}).values()
+        for repo_name, repo in (repos or {}).items()
+    ):
+        return
+
+    recommendation = Recommendation.APPROVE
+    problems = set()
+
+    for distro_file, repo_name, repo in (
+        (distro_file, repo_name, repo)
+        for distro in (index or {}).values()
+        for distro_file, repos in (distro or {}).items()
+        for repo_name, repo in (repos or {}).items()
+    ):
+        release = repo.get('release')
+        if not release:
+            # Repository is not released, we don't know the package names
+            continue
+
+        packages = release.get('packages')
+        if packages:
+            # Repository has an explicit list of package names
+            packages_to_check = [
+                name for name in packages
+                if getattr(name, '__lines__', None)
+            ]
+        elif getattr(release, '__lines__', None) or \
+                getattr(repo_name, '__lines__', None):
+            # Repository was just added or released and has in implicit
+            # package name
+            packages_to_check = [repo_name]
+        else:
+            # Released state of repository was not modified
+            continue
+
+        for package in packages_to_check:
+            lines = (
+                getattr(package, '__lines__', None) or
+                getattr(release, '__lines__', None)
+            )
+
+            if (
+                len(package) < 2 or
+                not re.match(r'^[a-z][a-z0-9_]*$', package) or
+                '__' in package
+            ):
+                recommendation = Recommendation.DISAPPROVE
+                problems.add(
+                    'Package names must comply with the mandatory rules of '
+                    'REP 144')
+                annotations.append(Annotation(
+                    distro_file, lines,
+                    f"The package name '{package}' does not comply with "
+                    'the mandatory rules of REP 144'))
+
+    if problems:
+        message = '\n- '.join([
+            'There are problems with the names of new packages:',
+        ] + sorted(problems))
+    else:
+        message = 'New packages are named appropriately'
+
+    criteria.append(Criterion(recommendation, message))
+
+
 def _check_gbp_org(criteria, annotations, index):
     # This check only applies to rolling
     rolling_index = index.get('rolling', {})
@@ -321,6 +397,7 @@ class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):
         logger.info('Performing analysis on ROS distribution changes...')
 
         _check_duplicates(criteria, annotations, index, entities)
+        _check_package_names(criteria, annotations, index)
         _check_gbp_org(criteria, annotations, index)
         _check_bloom_version(criteria, annotations, index)
 

--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -37,54 +37,53 @@ def _parse_version(version_str: str) -> Tuple[int, ...]:
     )
 
 
-def _check_duplicates(criteria, annotations, index, entities):
-    # Bypass check if no repo or package names were added/modified
+def _check_repository_names(criteria, annotations, index, entities):
+    # Bypass check if no repo names were added/modified
     if not any(
-        getattr(repo_name, '__lines__', None) or any(
-            getattr(package, '__lines__', None)
-            for package in repo.get('release', {}).get('packages', ())
-        )
+        getattr(repo_name, '__lines__', None)
         for distro in (index or {}).values()
         for repos in (distro or {}).values()
-        for repo_name, repo in (repos or {}).items()
+        for repo_name in (repos or {}).keys()
     ):
         return
 
     recommendation = Recommendation.APPROVE
+    problems = set()
 
-    # Names should be unique
-    for distro_name, distro_file, repo_name, repo in (
-        (distro_name, distro_file, repo_name, repo)
+    for distro_name, distro_file, repo_name in (
+        (distro_name, distro_file, repo_name)
         for distro_name, distro in (index or {}).items()
         for distro_file, repos in (distro or {}).items()
-        for repo_name, repo in (repos or {}).items()
+        for repo_name in (repos or {}).keys()
     ):
-        entities_to_check = (
-            name for name in
-            (repo_name, *repo.get('release', {}).get('packages', []))
-            if getattr(name, '__lines__', None)
-        )
-        for entity in entities_to_check:
-            for other_repo in entities.get(distro_name, {}).get(entity, ()):
-                if other_repo == repo_name:
-                    continue
+        if not getattr(repo_name, '__lines__', None):
+            continue
 
-                recommendation = Recommendation.DISAPPROVE
-                annotations.append(Annotation(
-                    distro_file, entity.__lines__,
-                    'This name is already used by the '
-                    f"'{other_repo}' repository"))
-                break
+        for other_repo in entities.get(
+            distro_name, {}
+        ).get(repo_name, ()):
+            if other_repo == repo_name:
+                continue
 
-    if recommendation != Recommendation.APPROVE:
-        message = 'There are problems with naming collision'
+            recommendation = Recommendation.DISAPPROVE
+            problems.add(
+                'Repository names must be unique across the distribution')
+            annotations.append(Annotation(
+                distro_file, repo_name.__lines__,
+                f"This name is already used by the '{other_repo}' repository"))
+            break
+
+    if problems:
+        message = '\n- '.join([
+            'There are problems with the names of new repositories:',
+        ] + sorted(problems))
     else:
-        message = 'New packages and repositories have unique names'
+        message = 'New repositories are named appropriately'
 
     criteria.append(Criterion(recommendation, message))
 
 
-def _check_package_names(criteria, annotations, index):
+def _check_package_names(criteria, annotations, index, entities):
     # Bypass check if no packages were added/modified, and no release stanzas
     # were added/modified which might use the repository name as a package
     # name.
@@ -103,9 +102,9 @@ def _check_package_names(criteria, annotations, index):
     recommendation = Recommendation.APPROVE
     problems = set()
 
-    for distro_file, repo_name, repo in (
-        (distro_file, repo_name, repo)
-        for distro in (index or {}).values()
+    for distro_name, distro_file, repo_name, repo in (
+        (distro_name, distro_file, repo_name, repo)
+        for distro_name, distro in (index or {}).items()
         for distro_file, repos in (distro or {}).items()
         for repo_name, repo in (repos or {}).items()
     ):
@@ -149,6 +148,21 @@ def _check_package_names(criteria, annotations, index):
                     distro_file, lines,
                     f"The package name '{package}' does not comply with "
                     'the mandatory rules of REP 144'))
+
+            for other_repo in entities.get(
+                distro_name, {}
+            ).get(package, ()):
+                if other_repo == repo_name:
+                    continue
+
+                recommendation = Recommendation.DISAPPROVE
+                problems.add(
+                    'Package names must be unique across the distribution')
+                annotations.append(Annotation(
+                    distro_file, lines,
+                    f"This name is already used by the '{other_repo}'"
+                    'repository'))
+                break
 
     if problems:
         message = '\n- '.join([
@@ -396,8 +410,8 @@ class RosdistroAnalyzer(ElementAnalyzerExtensionPoint):
 
         logger.info('Performing analysis on ROS distribution changes...')
 
-        _check_duplicates(criteria, annotations, index, entities)
-        _check_package_names(criteria, annotations, index)
+        _check_repository_names(criteria, annotations, index, entities)
+        _check_package_names(criteria, annotations, index, entities)
         _check_gbp_org(criteria, annotations, index)
         _check_bloom_version(criteria, annotations, index)
 

--- a/test/test_rosdistro_checks.py
+++ b/test/test_rosdistro_checks.py
@@ -118,6 +118,13 @@ EXISTING_DISTROS = {
                 'version': 'main',
             },
         },
+        'invalid__name_existing': {
+            'source': {
+                'type': 'git',
+                'url': 'https://example.com/invalid__name_existing.git',
+                'version': 'main',
+            },
+        },
     },
     'jazzy': {
         'existing_jazzy': {
@@ -140,6 +147,13 @@ CONTROL_DISTROS = {
                 'type': 'git',
                 'url': 'https://example.com/control_bravo.git',
                 'version': 'main',
+            },
+        },
+        'control_charlie': {
+            'release': {
+                'url':
+                    'https://github.com/ros2-gbp/control_charlie-release.git',
+                'version': '1.0.0-1',
             },
         },
     },
@@ -178,7 +192,30 @@ VIOLATIONS = {
             },
             'echo': {
                 'release': {
-                    'packages': ['duplicate_name'],
+                    'packages': ['duplicate_name', 'delta'],
+                },
+            },
+        },
+    },
+    'C': {
+        # This repo has explicit packages that violate REP 144
+        'rolling': {
+            'foxtrot': {
+                'release': {
+                    'packages': [
+                        'invalid__name', '1invalid', 'i', 'A_invalid'
+                    ],
+                },
+            },
+        },
+    },
+    'D': {
+        # This repo has an implicit package name that violates REP 144
+        'rolling': {
+            'invalid__repo_name': {
+                'release': {
+                    'url': 'https://example.com/invalid__repo_name.git',
+                    'version': '1.0.0-1',
                 },
             },
         },


### PR DESCRIPTION
As part of this change, I've refactored the `_check_duplicates` check and split it into `_check_package_names` and `_check_repository_names`, where the new REP 144 checks are also done as part of `_check_package_names` but those rules are not enforced for repository names.

This split should make it easier to add other checks based on package and/or repository names rather than adding new check functions and duplicating the bypass logic and enumeration loops in the future.

I used Gemini 3 here, but there was a lot of hand-holding.