### PR TITLE
Add a "neutral" disclaimer when adding pip-only rules

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdep.py
+++ b/rosdistro_reviewer/element_analyzer/rosdep.py
@@ -351,6 +351,29 @@ def _check_suitability(criteria, annotations, changed_rosdeps, key_counts):
     criteria.append(Criterion(recommendation, message))
 
 
+def _check_pip_disclaimer(criteria, annotations, changed_rosdeps):
+    if any(
+        isinstance(rules, dict) and
+        all(
+            isinstance(rule, dict) and set(rule.keys()) == {'pip'}
+            for rule in rules.values()
+        ) and
+        any(
+            any(
+                getattr(obj, '__lines__', None)
+                for obj in (key, os, rule, rule['pip'])
+            )
+            for os, rule in rules.items()
+        )
+        for changes in changed_rosdeps.values()
+        for key, rules in changes.items()
+    ):
+        criteria.append(Criterion(
+            Recommendation.NEUTRAL,
+            'Disclaimer: Pip-only rules cannot be used by packages on the '
+            'ROS buildfarm'))
+
+
 def _is_yaml_blob(item, depth) -> bool:
     return PurePosixPath(item.path).suffix == '.yaml'
 
@@ -432,5 +455,6 @@ class RosdepAnalyzer(ElementAnalyzerExtensionPoint):
         _check_platforms(criteria, annotations, changed_rosdeps)
         _check_installers(criteria, annotations, changed_rosdeps)
         _check_suitability(criteria, annotations, changed_rosdeps, key_counts)
+        _check_pip_disclaimer(criteria, annotations, changed_rosdeps)
 
         return criteria, annotations

--- a/test/test_rosdep_checks.py
+++ b/test/test_rosdep_checks.py
@@ -152,13 +152,6 @@ CONTROL_RULES = {
             },
             'ubuntu': ['python3-control-bravo'],
         },
-        'python3-control-kilo-pip': {
-            '*': {
-                'pip': {
-                    'packages': ['python3-control-kilo'],
-                },
-            },
-        },
         'python3-control-charlie': {
             'fedora': ['python3-control-charlie'],
             'ubuntu': None,
@@ -167,10 +160,28 @@ CONTROL_RULES = {
 }
 
 
+# This is a list of circumstances which require further review.
+SENSITIVE = {
+    '*': CONTROL_RULES,
+    'A': {
+        # This is a pip-only rule, which can't be used on the buildfarm
+        'python.yaml': {
+            'python3-control-kilo-pip': {
+                '*': {
+                    'pip': {
+                        'packages': ['python3-control-kilo'],
+                    },
+                },
+            },
+        },
+    },
+}
+
+
 # This is a list of violations to check for.
 # To avoid collisions, each check should use unique package names.
 VIOLATIONS = {
-    '*': CONTROL_RULES,
+    '*': _merge_all_rules(SENSITIVE.values()),
     'A': {
         # This key should end in -pip
         'python.yaml': {
@@ -298,17 +309,26 @@ VIOLATIONS = {
 
 
 def pytest_generate_tests(metafunc):
-    if 'violation_rules' not in metafunc.fixturenames:
-        return
-    combinations = {
-        ''.join(key_set): _merge_all_rules(map(VIOLATIONS.get, key_set))
-        for key_set in _all_combinations(sorted(VIOLATIONS.keys()))
-        if key_set != ('*',)
-    }
-    metafunc.parametrize(
-        'violation_rules',
-        combinations.values(),
-        ids=combinations.keys())
+    if 'violation_rules' in metafunc.fixturenames:
+        combinations = {
+            ''.join(key_set): _merge_all_rules(map(VIOLATIONS.get, key_set))
+            for key_set in _all_combinations(sorted(VIOLATIONS.keys()))
+            if key_set != ('*',)
+        }
+        metafunc.parametrize(
+            'violation_rules',
+            combinations.values(),
+            ids=combinations.keys())
+    if 'sensitive_rules' in metafunc.fixturenames:
+        combinations = {
+            ''.join(key_set): _merge_all_rules(map(SENSITIVE.get, key_set))
+            for key_set in _all_combinations(sorted(SENSITIVE.keys()))
+            if key_set != ('*',)
+        }
+        metafunc.parametrize(
+            'sensitive_rules',
+            combinations.values(),
+            ids=combinations.keys())
 
 
 def test_control(rosdep_repo):
@@ -364,6 +384,21 @@ def test_removal_only(rosdep_repo):
         (repo_dir / 'rosdep' / file_name).write_text('')
 
     assert (None, None) == extension.analyze(repo_dir)
+
+
+def test_sensitive(rosdep_repo, sensitive_rules):
+    repo_dir = Path(rosdep_repo.working_tree_dir)
+    extension = RosdepAnalyzer()
+
+    rules = _merge_two_rules(EXISTING_RULES, sensitive_rules)
+    for file_name, data in rules.items():
+        file_path = repo_dir / 'rosdep' / file_name
+        with file_path.open('w') as f:
+            yaml.dump(data, f)
+
+    criteria, annotations = extension.analyze(repo_dir)
+    assert criteria
+    assert any(Recommendation.APPROVE > c.recommendation for c in criteria)
 
 
 def test_violation(rosdep_repo, violation_rules):


### PR DESCRIPTION
This means that a PR which adds a new pip-only rosdep key will never be reviewed as `APPROVE`, but won't necessarily be `DISAPPROVE`.