### PR TITLE
Adjust tests to accommodate new rosdistro checks

### DIFF
--- a/test/test_rosdistro_checks.py
+++ b/test/test_rosdistro_checks.py
@@ -149,6 +149,8 @@ CONTROL_DISTROS = {
                 'version': 'main',
             },
         },
+    },
+    'jazzy': {
         'control_charlie': {
             'release': {
                 'url':
@@ -156,8 +158,6 @@ CONTROL_DISTROS = {
                 'version': '1.0.0-1',
             },
         },
-    },
-    'jazzy': {
         'control_delta': {
             'release': {
                 'url': 'https://github.com/other/control_delta-release.git',


### PR DESCRIPTION
There is a test regression at the intersection of two recently merged commits. This change adjusts the package tests to accommodate.