### PR TITLE
Report YAML parse errors in review feedback

### DIFF
--- a/rosdistro_reviewer/element_analyzer/__init__.py
+++ b/rosdistro_reviewer/element_analyzer/__init__.py
@@ -154,14 +154,17 @@ def analyze_yaml_error(
         target_ref=target_ref,
         head_ref=head_ref,
         paths=[yaml_path])
-    if not added_lines:
-        return None, None
-
-    for lines in added_lines.get(yaml_path, ()):
+    for lines in (added_lines or {}).get(yaml_path, ()):
         if error_line in lines:
             error_lines = range(error_line, error_line + 1)
             break
         elif error_line - 1 in lines:
+            # It is a common pattern that mistakes in YAML will only manifest
+            # as a syntax error on the following line. If the line wasn't
+            # modified but the line before it was, it is highly likely that
+            # changes on the line before caused the error. Either way, the
+            # line immediately after a change is considered part of the
+            # context of the review and should allow annotation.
             error_lines = range(error_line - 1, error_line + 1)
             break
     else:

--- a/rosdistro_reviewer/element_analyzer/__init__.py
+++ b/rosdistro_reviewer/element_analyzer/__init__.py
@@ -10,7 +10,9 @@ from typing import Tuple
 from colcon_core.plugin_system import instantiate_extensions
 from rosdistro_reviewer.review import Annotation
 from rosdistro_reviewer.review import Criterion
+from rosdistro_reviewer.review import Recommendation
 from rosdistro_reviewer.review import Review
+import yaml
 
 
 class ElementAnalyzerExtensionPoint:
@@ -94,7 +96,16 @@ def analyze(
                 head_ref = repo.commit(head_ref).hexsha
     review = Review(head_ref=head_ref)
     for analyzer_name, extension in extensions.items():
-        criteria, annotations = extension.analyze(path, target_ref, head_ref)
+        try:
+            criteria, annotations = extension.analyze(
+                path, target_ref, head_ref)
+        except yaml.error.MarkedYAMLError as e:
+            criteria, annotations = analyze_yaml_error(
+                e, path, target_ref, head_ref)
+            if not criteria and not annotations:
+                # If we can't represent the error as part of the review, let
+                # the exception bubble up so the error isn't lost.
+                raise
 
         if criteria:
             element = review.elements.setdefault(analyzer_name, [])
@@ -110,3 +121,61 @@ def analyze(
         return None
 
     return review
+
+
+def analyze_yaml_error(
+    exception: yaml.error.MarkedYAMLError,
+    path: Path,
+    target_ref: Optional[str] = None,
+    head_ref: Optional[str] = None,
+) -> Tuple[Optional[List[Criterion]], Optional[List[Annotation]]]:
+    """
+    Analyze a MarkedYAMLError and return review criteria and annotations.
+
+    :param exception: The underlying YAML error
+    :param path: Path on disk to the git repository
+    :param target_ref: The git ref to base the diff from
+    :param head_ref: The git ref where the changes have been made
+    :returns: A tuple with a list of criteria and a list of
+      annotations, or (None, None) if a review can't be generated
+    """
+    if not exception.problem_mark or not exception.problem_mark.name:
+        return None, None
+    yaml_path = exception.problem_mark.name
+    error_line = exception.problem_mark.line + 1
+
+    # We delay this import until after the GitPython
+    # logger has already been configured to avoid DEBUG
+    # messages on the console at import time
+    from rosdistro_reviewer.git_lines import get_added_lines
+
+    added_lines = get_added_lines(
+        path,
+        target_ref=target_ref,
+        head_ref=head_ref,
+        paths=[yaml_path])
+    if not added_lines:
+        return None, None
+
+    for lines in added_lines.get(yaml_path, ()):
+        if error_line in lines:
+            error_lines = range(error_line, error_line + 1)
+            break
+        elif error_line - 1 in lines:
+            error_lines = range(error_line - 1, error_line + 1)
+            break
+    else:
+        return None, None
+
+    reason = 'A YAML syntax error is blocking analysis'
+    criteria = [
+        Criterion(Recommendation.CRITICAL, reason),
+    ]
+    msg = f'YAML parsing error: {exception.problem}'
+    if exception.context:
+        msg += f' ({exception.context})'
+    annotations = [
+        Annotation(yaml_path, error_lines, msg),
+    ]
+
+    return criteria, annotations

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -55,6 +55,7 @@ pytest
 rangeify
 representer
 returncode
+rglob
 rhel
 rosdep
 rosdeps

--- a/test/test_analyze.py
+++ b/test/test_analyze.py
@@ -7,11 +7,15 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+from colcon_core.generic_decorator import GenericDecorator
+from colcon_core.plugin_system import satisfies_version
+import pytest
 from rosdistro_reviewer.element_analyzer import analyze
 from rosdistro_reviewer.element_analyzer import ElementAnalyzerExtensionPoint
 from rosdistro_reviewer.review import Annotation
 from rosdistro_reviewer.review import Criterion
 from rosdistro_reviewer.review import Recommendation
+import yaml
 
 
 class DuplicateFeedbackAnalyzer(ElementAnalyzerExtensionPoint):
@@ -48,6 +52,115 @@ class DuplicateFeedbackAnalyzer(ElementAnalyzerExtensionPoint):
                 message='Unique annotation'),
         ]
         return criteria, annotations
+
+
+class YamlParsingAnalyzer(ElementAnalyzerExtensionPoint):
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            ElementAnalyzerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def analyze(  # noqa: D102
+        self,
+        path: Path,
+        target_ref: Optional[str] = None,
+        head_ref: Optional[str] = None,
+    ) -> Tuple[Optional[List[Criterion]], Optional[List[Annotation]]]:
+        for yaml_file in path.rglob('*.yaml'):
+            with yaml_file.open('r') as f:
+                stream = GenericDecorator(
+                    f, name=str(yaml_file.relative_to(path)))
+                yaml.load(stream, yaml.SafeLoader)
+        return None, None
+
+
+def test_analyze(empty_repo):
+    path = Path(empty_repo.working_tree_dir)
+
+    review = analyze(path, extensions={})
+
+    assert review is None
+
+
+def test_analyze_bad_yaml(empty_repo):
+    path = Path(empty_repo.working_tree_dir)
+
+    (path / 'sub').mkdir()
+    (path / 'sub' / 'bad.yaml').write_text(
+        'alpha:\n'
+        '  bravo: [@charlie]\n'
+        'delta: 1\n'
+        '\n')
+    empty_repo.index.add(['sub/bad.yaml'])
+
+    extensions = {
+        'yaml_parsing': YamlParsingAnalyzer(),
+    }
+    review = analyze(path, extensions=extensions)
+
+    assert review
+    assert review.recommendation == Recommendation.CRITICAL
+    assert len(review.annotations) == 1
+    assert review.annotations[0].file == str(Path('sub/bad.yaml'))
+
+
+def test_analyze_bad_yaml_after(empty_repo):
+    path = Path(empty_repo.working_tree_dir)
+
+    (path / 'sub').mkdir()
+    (path / 'sub' / 'bad.yaml').write_text(
+        'alpha:\n'
+        '  bravo: [charlie]\n'
+        'delta: 1\n'
+        '\n')
+    empty_repo.index.add(['sub/bad.yaml'])
+    empty_repo.index.commit('Add good YAML')
+
+    (path / 'sub' / 'bad.yaml').write_text(
+        'alpha:\n'
+        '  bravo: [charlie\n'
+        'delta: 1\n'
+        '\n')
+
+    extensions = {
+        'yaml_parsing': YamlParsingAnalyzer(),
+    }
+    review = analyze(path, extensions=extensions)
+
+    assert review
+    assert review.recommendation == Recommendation.CRITICAL
+    assert len(review.annotations) == 1
+    assert review.annotations[0].file == str(Path('sub/bad.yaml'))
+
+
+def test_analyze_bad_yaml_unrelated(empty_repo):
+    path = Path(empty_repo.working_tree_dir)
+
+    (path / 'sub').mkdir()
+    (path / 'sub' / 'bad.yaml').write_text(
+        'alpha:\n'
+        '  bravo: [@charlie]\n'
+        'delta: 1\n'
+        '\n')
+    empty_repo.index.add(['sub/bad.yaml'])
+    empty_repo.index.commit('Add bad YAML')
+
+    (path / 'sub' / 'bad.yaml').write_text(
+        'alpha:\n'
+        '  bravo: [@charlie]\n'
+        'delta: 1\n'
+        'echo: true\n'
+        '\n')
+
+    extensions = {
+        'yaml_parsing': YamlParsingAnalyzer(),
+    }
+    with pytest.raises(yaml.error.MarkedYAMLError) as exc_info:
+        analyze(path, extensions=extensions)
+
+    assert exc_info.value.problem_mark is not None
+    assert exc_info.value.problem_mark.name == str(Path('sub/bad.yaml'))
 
 
 def test_analyze_deduplication() -> None:

--- a/test/test_analyze.py
+++ b/test/test_analyze.py
@@ -82,6 +82,13 @@ def test_analyze(empty_repo):
 
     assert review is None
 
+    empty_repo.index.commit('Empty commit')
+
+    review = analyze(
+        path, extensions={}, target_ref='HEAD~1', head_ref='HEAD')
+
+    assert review is None
+
 
 def test_analyze_bad_yaml(empty_repo):
     path = Path(empty_repo.working_tree_dir)
@@ -98,6 +105,17 @@ def test_analyze_bad_yaml(empty_repo):
         'yaml_parsing': YamlParsingAnalyzer(),
     }
     review = analyze(path, extensions=extensions)
+
+    assert review
+    assert review.recommendation == Recommendation.CRITICAL
+    assert len(review.annotations) == 1
+    assert review.annotations[0].file == str(Path('sub/bad.yaml'))
+
+    empty_repo.index.add(['sub/bad.yaml'])
+    empty_repo.index.commit('Add bad YAML')
+
+    review = analyze(
+        path, extensions=extensions, target_ref='HEAD~1', head_ref='HEAD')
 
     assert review
     assert review.recommendation == Recommendation.CRITICAL
@@ -133,6 +151,17 @@ def test_analyze_bad_yaml_after(empty_repo):
     assert len(review.annotations) == 1
     assert review.annotations[0].file == str(Path('sub/bad.yaml'))
 
+    empty_repo.index.add(['sub/bad.yaml'])
+    empty_repo.index.commit('Add bad YAML')
+
+    review = analyze(
+        path, extensions=extensions, target_ref='HEAD~1', head_ref='HEAD')
+
+    assert review
+    assert review.recommendation == Recommendation.CRITICAL
+    assert len(review.annotations) == 1
+    assert review.annotations[0].file == str(Path('sub/bad.yaml'))
+
 
 def test_analyze_bad_yaml_unrelated(empty_repo):
     path = Path(empty_repo.working_tree_dir)
@@ -158,6 +187,16 @@ def test_analyze_bad_yaml_unrelated(empty_repo):
     }
     with pytest.raises(yaml.error.MarkedYAMLError) as exc_info:
         analyze(path, extensions=extensions)
+
+    assert exc_info.value.problem_mark is not None
+    assert exc_info.value.problem_mark.name == str(Path('sub/bad.yaml'))
+
+    empty_repo.index.add(['sub/bad.yaml'])
+    empty_repo.index.commit('Add unrelated change')
+
+    with pytest.raises(yaml.error.MarkedYAMLError) as exc_info:
+        analyze(
+            path, extensions=extensions, target_ref='HEAD~1', head_ref='HEAD')
 
     assert exc_info.value.problem_mark is not None
     assert exc_info.value.problem_mark.name == str(Path('sub/bad.yaml'))


### PR DESCRIPTION
When PyYAML encounters a syntax error, it reports enough information in the exception for us to include the error in the review. The tool will still return a non-zero exit code, but rather than showing a Python backtrace, an annotation will show the location of the problem and include the YAML parser error message.

Requires #87
Requires #88

Assisted-by: Gemini 3.5 Flash