### PR TITLE
Add Recommendation.CRITICAL result

### DIFF
--- a/doc/element_analyzers.rst
+++ b/doc/element_analyzers.rst
@@ -66,11 +66,12 @@ Analyzers use three main data structures to represent the :py:class:`~.rosdistro
 Recommendation
 ~~~~~~~~~~~~~~
 
-The :py:class:`~.rosdistro_reviewer.review.Recommendation` is an :py:class:`~.enum.IntEnum` that represents the overall outcome of a criterion. It has three possible values:
+The :py:class:`~.rosdistro_reviewer.review.Recommendation` is an :py:class:`~.enum.IntEnum` that represents the overall outcome of a criterion. It has four possible values:
 
 *   :py:attr:`Recommendation.APPROVE`: The changes satisfy the criterion.
 *   :py:attr:`Recommendation.NEUTRAL`: The changes are not applicable to the criterion, or the analysis is inconclusive.
 *   :py:attr:`Recommendation.DISAPPROVE`: The changes do not satisfy the criterion and need to be addressed.
+*   :py:attr:`Recommendation.CRITICAL`: The changes contain critical issues that prevent other checks from running, resulting in a non-zero exit code.
 
 Criterion
 ~~~~~~~~~

--- a/rosdistro_reviewer/review.py
+++ b/rosdistro_reviewer/review.py
@@ -77,6 +77,7 @@ def _format_code_block(
 class Recommendation(IntEnum):
     """Singular recommendations a review can make."""
 
+    CRITICAL = -1
     DISAPPROVE = 0
     NEUTRAL = 1
     APPROVE = 2
@@ -84,6 +85,7 @@ class Recommendation(IntEnum):
     def as_symbol(self) -> str:
         """Convert the recommendation to a unicode symbol."""
         return {
+            Recommendation.CRITICAL: '\U0001F6D1',
             Recommendation.DISAPPROVE: '\U0000274C',
             Recommendation.NEUTRAL: '\U0001F4DD',
             Recommendation.APPROVE: '\U00002705',
@@ -92,6 +94,7 @@ class Recommendation(IntEnum):
     def as_text(self) -> str:
         """Convert the recommendation to a shot text summary."""
         return {
+            Recommendation.CRITICAL: 'Changes required',
             Recommendation.DISAPPROVE: 'Changes recommended',
             Recommendation.NEUTRAL: 'No changes recommended, '
                                     'but requires further review',

--- a/rosdistro_reviewer/submitter/github.py
+++ b/rosdistro_reviewer/submitter/github.py
@@ -88,6 +88,7 @@ class GitHubSubmitter(ReviewSubmitterExtensionPoint):
         auth = Auth.Token(token) if token else None
 
         RECOMMENDATION_EVENTS = {
+            Recommendation.CRITICAL: 'REQUEST_CHANGES',
             Recommendation.DISAPPROVE: 'REQUEST_CHANGES',
             Recommendation.NEUTRAL: 'COMMENT',
             Recommendation.APPROVE: 'APPROVE',

--- a/rosdistro_reviewer/verb/review.py
+++ b/rosdistro_reviewer/verb/review.py
@@ -9,6 +9,7 @@ from colcon_core.logging import get_effective_console_level
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.verb import VerbExtensionPoint
 from rosdistro_reviewer.element_analyzer import analyze
+from rosdistro_reviewer.review import Recommendation
 from rosdistro_reviewer.submitter import add_review_submitter_arguments
 from rosdistro_reviewer.submitter import submit_review
 
@@ -55,9 +56,14 @@ class ReviewVerb(VerbExtensionPoint):
             root,
             target_ref=context.args.target_ref,
             head_ref=context.args.head_ref)
+
         if review:
             text_root = root if context.args.head_ref is None else None
             print('\n' + review.to_text(root=text_root) + '\n')
 
             submit_review(context.args, review)
+
+            if review.recommendation <= Recommendation.CRITICAL:
+                return 1
+
         return 0

--- a/test/test_verb_review.py
+++ b/test/test_verb_review.py
@@ -14,6 +14,8 @@ import pytest
 from rosdistro_reviewer.element_analyzer import ElementAnalyzerExtensionPoint
 from rosdistro_reviewer.review import Annotation
 from rosdistro_reviewer.review import Criterion
+from rosdistro_reviewer.review import Recommendation
+from rosdistro_reviewer.review import Review
 from rosdistro_reviewer.submitter import ReviewSubmitterExtensionPoint
 from rosdistro_reviewer.verb.review import ReviewVerb
 
@@ -94,3 +96,34 @@ def test_verb_review_no_repo(tmp_path):
     ):
         with pytest.raises(RuntimeError):
             extension.main(context=context)
+
+
+@pytest.mark.parametrize('recommendation,expected_exit_code', [
+    (Recommendation.CRITICAL, 1),
+    (Recommendation.DISAPPROVE, 0),
+    (Recommendation.NEUTRAL, 0),
+    (Recommendation.APPROVE, 0),
+], ids=['CRITICAL', 'DISAPPROVE', 'NEUTRAL', 'APPROVE'])
+def test_verb_review_return_codes(
+    empty_repo, recommendation, expected_exit_code,
+) -> None:
+    extension = ReviewVerb()
+    extension.add_arguments(parser=Mock())
+
+    context = CommandContext(
+        command_name='rosdistro-reviewer',
+        args=Mock())
+    context.args.head_ref = None
+    context.args.target_ref = None
+
+    review = Review()
+    review.elements['dummy'] = [Criterion(recommendation, 'dummy reason')]
+
+    with patch(
+        'rosdistro_reviewer.verb.review.Path.cwd',
+        return_value=Path(empty_repo.working_tree_dir),
+    ), patch(
+        'rosdistro_reviewer.verb.review.analyze',
+        return_value=review,
+    ):
+        assert expected_exit_code == extension.main(context=context)


### PR DESCRIPTION
The intent of this value is to indicate that there were problems with the changes which were so severe that some or all of the checks that should have run were not attempted.

Of note, this recommendation should be used only when the source of the problem is part of the changes being analyzed and shouldn't be used when external factors (like remote resource access) cause the failure.

Assisted-by: Gemini 3.5 Flash