### PR TITLE
Ensure filenames are reported correctly from YAML parsing

### DIFF
--- a/rosdistro_reviewer/element_analyzer/rosdistro.py
+++ b/rosdistro_reviewer/element_analyzer/rosdistro.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+from colcon_core.generic_decorator import GenericDecorator
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from git import Repo
@@ -340,15 +341,17 @@ def _read_index(
             tree = repo.tree(head_ref)
             if 'index-v4.yaml' not in tree:
                 return None
-            index = yaml.load(
-                        tree['index-v4.yaml'].data_stream,
-                        yaml.SafeLoader)
+            stream = GenericDecorator(
+                tree['index-v4.yaml'].data_stream,
+                name='index-v4.yaml')
+            index = yaml.load(stream, yaml.SafeLoader)
     else:
         index_path = path / 'index-v4.yaml'
         if not index_path.is_file():
             return None
         with index_path.open('r') as f:
-            index = yaml.load(f, yaml.SafeLoader)
+            stream = GenericDecorator(f, name='index-v4.yaml')
+            index = yaml.load(stream, yaml.SafeLoader)
     if not index or not index.get('distributions'):
         return None
 

--- a/rosdistro_reviewer/element_analyzer/yamllint.py
+++ b/rosdistro_reviewer/element_analyzer/yamllint.py
@@ -76,7 +76,7 @@ def _get_previous_keys(
     :param yaml_path: Relative path to the YAML file.
     :returns: Mapping from line number to previous key line number.
     """
-    stream = GenericDecorator(io.StringIO(raw_data), name=yaml_path)
+    stream = GenericDecorator(io.StringIO(raw_data), name=str(Path(yaml_path)))
     data = yaml.load(stream, Loader=AnnotatedSafeLoader)
     previous_keys = {}
 

--- a/rosdistro_reviewer/element_analyzer/yamllint.py
+++ b/rosdistro_reviewer/element_analyzer/yamllint.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
+import io
 from pathlib import Path
 from pathlib import PurePosixPath
 from typing import List
@@ -9,6 +10,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Tuple
 
+from colcon_core.generic_decorator import GenericDecorator
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from git import Repo
@@ -63,14 +65,19 @@ def _get_changed_yaml(
     return changes
 
 
-def _get_previous_keys(raw_data: str) -> Mapping[int, int]:
+def _get_previous_keys(
+    raw_data: str,
+    yaml_path: str,
+) -> Mapping[int, int]:
     """
     For each key, determine what key (if any) precedes it in the file.
 
     :param raw_data: The un-parsed YAML text.
+    :param yaml_path: Relative path to the YAML file.
     :returns: Mapping from line number to previous key line number.
     """
-    data = yaml.load(raw_data, Loader=AnnotatedSafeLoader)
+    stream = GenericDecorator(io.StringIO(raw_data), name=yaml_path)
+    data = yaml.load(stream, Loader=AnnotatedSafeLoader)
     previous_keys = {}
 
     def _process_level(maybe_mapping):
@@ -173,7 +180,7 @@ class YamllintAnalyzer(ElementAnalyzerExtensionPoint):
 
                     # lazy-load
                     if previous_keys is None:
-                        previous_keys = _get_previous_keys(data)
+                        previous_keys = _get_previous_keys(data, yaml_path)
 
                     probable_culprit = previous_keys.get(problem.line)
                     if (

--- a/rosdistro_reviewer/git_lines.py
+++ b/rosdistro_reviewer/git_lines.py
@@ -99,6 +99,6 @@ def get_added_lines(
         return None
 
     return {
-        path: list(_rangeify(sorted(lines.get(os.path.normpath(path), ()))))
+        path: list(_rangeify(sorted(lines.get(path, ()))))
         for path in (paths if paths is not None else lines.keys())
     }

--- a/rosdistro_reviewer/git_lines.py
+++ b/rosdistro_reviewer/git_lines.py
@@ -99,6 +99,6 @@ def get_added_lines(
         return None
 
     return {
-        path: list(_rangeify(sorted(lines.get(path, ()))))
+        path: list(_rangeify(sorted(lines.get(os.path.normpath(path), ()))))
         for path in (paths if paths is not None else lines.keys())
     }

--- a/rosdistro_reviewer/yaml_changes.py
+++ b/rosdistro_reviewer/yaml_changes.py
@@ -89,13 +89,13 @@ def get_changed_yaml(
                 git_yaml_path = str(PurePosixPath(Path(yaml_path)))
                 stream = GenericDecorator(
                     repo.tree(head_ref)[git_yaml_path].data_stream,
-                    name=yaml_path)
+                    name=str(Path(yaml_path)))
                 data[yaml_path] = yaml.load(
                     stream, Loader=AnnotatedSafeLoader)
     else:
         for yaml_path in paths:
             with (path / yaml_path).open('r') as f:
-                stream = GenericDecorator(f, name=yaml_path)
+                stream = GenericDecorator(f, name=str(Path(yaml_path)))
                 data[yaml_path] = yaml.load(
                     stream, Loader=AnnotatedSafeLoader)
 

--- a/rosdistro_reviewer/yaml_changes.py
+++ b/rosdistro_reviewer/yaml_changes.py
@@ -8,6 +8,7 @@ from typing import Iterable
 from typing import Mapping
 from typing import Optional
 
+from colcon_core.generic_decorator import GenericDecorator
 from git import Repo
 from rosdistro_reviewer.git_lines import get_added_lines
 from rosdistro_reviewer.yaml_lines import AnnotatedSafeLoader
@@ -86,13 +87,17 @@ def get_changed_yaml(
         with Repo(path) as repo:
             for yaml_path in paths:
                 git_yaml_path = str(PurePosixPath(Path(yaml_path)))
-                data[yaml_path] = yaml.load(
+                stream = GenericDecorator(
                     repo.tree(head_ref)[git_yaml_path].data_stream,
-                    Loader=AnnotatedSafeLoader)
+                    name=yaml_path)
+                data[yaml_path] = yaml.load(
+                    stream, Loader=AnnotatedSafeLoader)
     else:
         for yaml_path in paths:
             with (path / yaml_path).open('r') as f:
-                data[yaml_path] = yaml.load(f, Loader=AnnotatedSafeLoader)
+                stream = GenericDecorator(f, name=yaml_path)
+                data[yaml_path] = yaml.load(
+                    stream, Loader=AnnotatedSafeLoader)
 
     for yaml_path, yaml_data in data.items():
         _isolate(yaml_data, changes.get(yaml_path, ()))

--- a/test/test_rosdistro_checks.py
+++ b/test/test_rosdistro_checks.py
@@ -415,3 +415,46 @@ def test_bloom_version_check(rosdistro_index_repo, tmp_path):
             if 'Failed to parse GitHub event file' in c.rationale]
         assert len(bloom_c) == 1
         assert bloom_c[0].recommendation == Recommendation.NEUTRAL
+
+
+@pytest.fixture
+def repo_with_syntax_error_index(rosdistro_index_repo: Repo) -> Repo:
+    assert rosdistro_index_repo.working_tree_dir is not None
+    repo_dir = Path(rosdistro_index_repo.working_tree_dir)
+    index_path = repo_dir / 'index-v4.yaml'
+    index_path.write_text('---\nfoo: @bar\n')
+    return rosdistro_index_repo
+
+
+def test_rosdistro_syntax_error_on_disk(
+    repo_with_syntax_error_index: Repo,
+) -> None:
+    assert repo_with_syntax_error_index.working_tree_dir is not None
+    repo_dir = Path(repo_with_syntax_error_index.working_tree_dir)
+    extension = RosdistroAnalyzer()
+
+    with pytest.raises(yaml.MarkedYAMLError) as e:
+        extension.analyze(repo_dir)
+
+    assert e.value.problem_mark is not None
+    assert e.value.problem_mark.name == 'index-v4.yaml'
+    assert e.value.problem_mark.line == 1
+
+
+def test_rosdistro_syntax_error_in_git_ref(
+    repo_with_syntax_error_index: Repo,
+) -> None:
+    assert repo_with_syntax_error_index.working_tree_dir is not None
+    repo_dir = Path(repo_with_syntax_error_index.working_tree_dir)
+    extension = RosdistroAnalyzer()
+
+    index_path = repo_dir / 'index-v4.yaml'
+    repo_with_syntax_error_index.index.add(str(index_path))
+    repo_with_syntax_error_index.index.commit('Commit invalid index')
+
+    with pytest.raises(yaml.MarkedYAMLError) as e:
+        extension.analyze(repo_dir, target_ref='HEAD~1', head_ref='HEAD')
+
+    assert e.value.problem_mark is not None
+    assert e.value.problem_mark.name == 'index-v4.yaml'
+    assert e.value.problem_mark.line == 1

--- a/test/test_yaml_changes.py
+++ b/test/test_yaml_changes.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from pathlib import Path
+
+from git import Repo
+import pytest
+from rosdistro_reviewer.yaml_changes import get_changed_yaml
+import yaml
+
+
+@pytest.fixture
+def repo_with_invalid_yaml(empty_repo: Repo) -> Repo:
+    assert empty_repo.working_tree_dir
+    repo_dir = Path(empty_repo.working_tree_dir)
+
+    subdir = repo_dir / 'subdir'
+    subdir.mkdir()
+
+    yaml_file = subdir / 'test.yaml'
+    yaml_file.write_text('foo:\n  bar: baz\n')
+
+    empty_repo.index.add(str(yaml_file))
+    empty_repo.index.commit('Add test.yaml')
+
+    # Modify it to contain a syntax error.
+    yaml_file.write_text('---\nfoo: @bar\n')
+
+    return empty_repo
+
+
+def test_yaml_syntax_error_on_disk(repo_with_invalid_yaml: Repo) -> None:
+    assert repo_with_invalid_yaml.working_tree_dir is not None
+    repo_dir = Path(repo_with_invalid_yaml.working_tree_dir)
+
+    yaml_path = 'subdir/test.yaml'
+
+    with pytest.raises(yaml.MarkedYAMLError) as e:
+        get_changed_yaml(
+            repo_dir,
+            [yaml_path],
+        )
+
+    assert e.value.problem_mark is not None
+    assert e.value.problem_mark.name == yaml_path
+    assert e.value.problem_mark.line == 1
+
+
+def test_yaml_syntax_error_in_git_ref(repo_with_invalid_yaml: Repo) -> None:
+    assert repo_with_invalid_yaml.working_tree_dir is not None
+    repo_dir = Path(repo_with_invalid_yaml.working_tree_dir)
+
+    yaml_path = 'subdir/test.yaml'
+    yaml_file = repo_dir / yaml_path
+
+    repo_with_invalid_yaml.index.add(str(yaml_file))
+    repo_with_invalid_yaml.index.commit('Commit invalid yaml')
+
+    with pytest.raises(yaml.MarkedYAMLError) as e:
+        get_changed_yaml(
+            repo_dir,
+            [yaml_path],
+            target_ref='HEAD~1',
+            head_ref='HEAD',
+        )
+
+    assert e.value.problem_mark is not None
+    assert e.value.problem_mark.name == yaml_path
+    assert e.value.problem_mark.line == 1

--- a/test/test_yaml_changes.py
+++ b/test/test_yaml_changes.py
@@ -42,7 +42,7 @@ def test_yaml_syntax_error_on_disk(repo_with_invalid_yaml: Repo) -> None:
         )
 
     assert e.value.problem_mark is not None
-    assert e.value.problem_mark.name == yaml_path
+    assert e.value.problem_mark.name == str(Path(yaml_path))
     assert e.value.problem_mark.line == 1
 
 
@@ -65,5 +65,5 @@ def test_yaml_syntax_error_in_git_ref(repo_with_invalid_yaml: Repo) -> None:
         )
 
     assert e.value.problem_mark is not None
-    assert e.value.problem_mark.name == yaml_path
+    assert e.value.problem_mark.name == str(Path(yaml_path))
     assert e.value.problem_mark.line == 1

--- a/test/test_yamllint_checks.py
+++ b/test/test_yamllint_checks.py
@@ -222,7 +222,7 @@ def test_yamllint_syntax_error_on_disk(
         extension.analyze(repo_dir)
 
     assert e.value.problem_mark is not None
-    assert e.value.problem_mark.name == yaml_path
+    assert e.value.problem_mark.name == str(Path(yaml_path))
     assert e.value.problem_mark.line == 4
 
 
@@ -243,5 +243,5 @@ def test_yamllint_syntax_error_in_git_ref(
         extension.analyze(repo_dir, target_ref='HEAD~1', head_ref='HEAD')
 
     assert e.value.problem_mark is not None
-    assert e.value.problem_mark.name == yaml_path
+    assert e.value.problem_mark.name == str(Path(yaml_path))
     assert e.value.problem_mark.line == 4

--- a/test/test_yamllint_checks.py
+++ b/test/test_yamllint_checks.py
@@ -8,6 +8,7 @@ from git import Repo
 import pytest
 from rosdistro_reviewer.element_analyzer.yamllint import YamllintAnalyzer
 from rosdistro_reviewer.review import Recommendation
+import yaml
 
 # The control prefix intentionally contains a violation
 # to verify that we only surface problems related to new lines
@@ -167,3 +168,80 @@ def test_violation(repo_with_yaml, violation):
     criteria, annotations = extension.analyze(repo_dir)
     assert criteria and annotations
     assert any(Recommendation.APPROVE != c.recommendation for c in criteria)
+
+
+@pytest.fixture
+def repo_with_yamllint_and_yaml(empty_repo: Repo) -> Repo:
+    assert empty_repo.working_tree_dir is not None
+    repo_dir = Path(empty_repo.working_tree_dir)
+
+    yamllint_file = repo_dir / '.yamllint'
+    yamllint_file.write_text('\n'.join((
+        '---',
+        'extends: default',
+        'rules:',
+        '  key-ordering: enable',
+    )) + '\n')
+
+    yaml_file = repo_dir / 'subdir' / 'file.yaml'
+    yaml_file.parent.mkdir(exist_ok=True)
+
+    # Commit pre-existing syntax error `@bar`
+    # Alone, this will not cause the yamllint analyzer to parse the YAML
+    yaml_file.write_text('\n'.join((
+        '---',
+        'bravo: charlie',
+        'yankee: @bar',
+    )) + '\n')
+    empty_repo.index.add(str(yaml_file))
+    empty_repo.index.add(str(yamllint_file))
+    empty_repo.index.commit('Add base YAML')
+
+    # Introduce zulu_out_of_order to trigger parsing
+    yaml_file.write_text('\n'.join((
+        '---',
+        'bravo: charlie',
+        'zulu_out_of_order:',
+        '  - alpha',
+        'yankee: @bar',
+    )) + '\n')
+
+    return empty_repo
+
+
+def test_yamllint_syntax_error_on_disk(
+    repo_with_yamllint_and_yaml: Repo,
+) -> None:
+    assert repo_with_yamllint_and_yaml.working_tree_dir is not None
+    repo_dir = Path(repo_with_yamllint_and_yaml.working_tree_dir)
+    extension = YamllintAnalyzer()
+
+    yaml_path = 'subdir/file.yaml'
+
+    with pytest.raises(yaml.MarkedYAMLError) as e:
+        extension.analyze(repo_dir)
+
+    assert e.value.problem_mark is not None
+    assert e.value.problem_mark.name == yaml_path
+    assert e.value.problem_mark.line == 4
+
+
+def test_yamllint_syntax_error_in_git_ref(
+    repo_with_yamllint_and_yaml: Repo,
+) -> None:
+    assert repo_with_yamllint_and_yaml.working_tree_dir is not None
+    repo_dir = Path(repo_with_yamllint_and_yaml.working_tree_dir)
+    extension = YamllintAnalyzer()
+
+    yaml_path = 'subdir/file.yaml'
+    yaml_file = repo_dir / yaml_path
+
+    repo_with_yamllint_and_yaml.index.add(str(yaml_file))
+    repo_with_yamllint_and_yaml.index.commit('Commit invalid YAML')
+
+    with pytest.raises(yaml.MarkedYAMLError) as e:
+        extension.analyze(repo_dir, target_ref='HEAD~1', head_ref='HEAD')
+
+    assert e.value.problem_mark is not None
+    assert e.value.problem_mark.name == yaml_path
+    assert e.value.problem_mark.line == 4


### PR DESCRIPTION
When PyYAML encounters a problem in the raw text, it includes the location of the error in the reported exception. It gets the filename from the `name` attribute (if available) on the stream object.

This change wraps every stream that we pass to PyYAML for parsing to ensure that the `name` attribute is set. It specifically uses the repository-relative path to the file, the same one that's used elsewhere in the project.

Assisted-by: Gemini 3.5 Flash