### PR TITLE
Drop verbatim duplicated feedback from generated reviews

### DIFF
--- a/rosdistro_reviewer/element_analyzer/__init__.py
+++ b/rosdistro_reviewer/element_analyzer/__init__.py
@@ -97,11 +97,14 @@ def analyze(
         criteria, annotations = extension.analyze(path, target_ref, head_ref)
 
         if criteria:
-            review.elements.setdefault(analyzer_name, [])
-            review.elements[analyzer_name].extend(criteria)
+            element = review.elements.setdefault(analyzer_name, [])
+            for criterion in criteria:
+                if criterion not in element:
+                    element.append(criterion)
 
-        if annotations:
-            review.annotations.extend(annotations)
+        for annotation in annotations or ():
+            if annotation not in review.annotations:
+                review.annotations.append(annotation)
 
     if not review.elements and not review.annotations:
         return None

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -9,6 +9,7 @@ committish
 connectionpool
 corge
 debian
+deduplication
 deserialized
 diffs
 distro

--- a/test/test_analyze.py
+++ b/test/test_analyze.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from pathlib import Path
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from rosdistro_reviewer.element_analyzer import analyze
+from rosdistro_reviewer.element_analyzer import ElementAnalyzerExtensionPoint
+from rosdistro_reviewer.review import Annotation
+from rosdistro_reviewer.review import Criterion
+from rosdistro_reviewer.review import Recommendation
+
+
+class DuplicateFeedbackAnalyzer(ElementAnalyzerExtensionPoint):
+
+    def analyze(
+        self,
+        path: Path,
+        target_ref: Optional[str] = None,
+        head_ref: Optional[str] = None,
+    ) -> Tuple[Optional[List[Criterion]], Optional[List[Annotation]]]:
+        criteria = [
+            Criterion(
+                recommendation=Recommendation.APPROVE,
+                rationale='Things look great'),
+            Criterion(
+                recommendation=Recommendation.APPROVE,
+                rationale='Things look great'),
+            Criterion(
+                recommendation=Recommendation.DISAPPROVE,
+                rationale='Some other check'),
+        ]
+        annotations = [
+            Annotation(
+                file='foo.yaml',
+                lines=range(1, 2),
+                message='Duplicate annotation'),
+            Annotation(
+                file='foo.yaml',
+                lines=range(1, 2),
+                message='Duplicate annotation'),
+            Annotation(
+                file='bar.yaml',
+                lines=range(1, 2),
+                message='Unique annotation'),
+        ]
+        return criteria, annotations
+
+
+def test_analyze_deduplication() -> None:
+    extensions: Dict[str, ElementAnalyzerExtensionPoint] = {
+        'duplicate': DuplicateFeedbackAnalyzer()
+    }
+    review = analyze(Path(), extensions=extensions)
+    assert review is not None
+
+    # Check criteria de-duplication
+    assert 'duplicate' in review.elements
+    criteria = review.elements['duplicate']
+    assert len(criteria) == 2
+    assert criteria[0] == Criterion(
+        recommendation=Recommendation.APPROVE,
+        rationale='Things look great')
+    assert criteria[1] == Criterion(
+        recommendation=Recommendation.DISAPPROVE,
+        rationale='Some other check')
+
+    # Check annotations de-duplication
+    assert len(review.annotations) == 2
+    assert review.annotations[0] == Annotation(
+        file='foo.yaml',
+        lines=range(1, 2),
+        message='Duplicate annotation')
+    assert review.annotations[1] == Annotation(
+        file='bar.yaml',
+        lines=range(1, 2),
+        message='Unique annotation')


### PR DESCRIPTION
When generating a review, drop any verbatim duplicate feedback from the review. Of note, this does not "merge" the results of a previously generated review with the new (or persisting) feedback, but ensures that the new review doesn't contain duplicate feedback itself.

Assisted-by: Gemini 3.5 Flash