### PR TITLE
In text review, group annotations appearing on same lines

### DIFF
--- a/rosdistro_reviewer/review.py
+++ b/rosdistro_reviewer/review.py
@@ -10,6 +10,7 @@ import textwrap
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 
@@ -174,15 +175,20 @@ class Review:
             _bubblify_text(message, width=width - 2),
             ' ')
 
+        grouped_annotations: Dict[Tuple[str, range], List[str]] = {}
         for annotation in self.annotations:
+            key = (annotation.file, annotation.lines)
+            grouped_annotations.setdefault(key, []).append(annotation.message)
+
+        for (file, lines), messages in grouped_annotations.items():
             result += '\n' + textwrap.indent(
                 '\n' + _bubblify_text([
                     _format_code_block(
-                        annotation.file,
-                        annotation.lines,
+                        file,
+                        lines,
                         width=width - 9,
                         root=root),
-                    annotation.message,
+                    *messages,
                 ], width=width - 5),
                 '  ¦ ', predicate=lambda _: True)
 

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -53,3 +53,20 @@ def test_to_text():
     assert 'bar' in text
     assert Recommendation.DISAPPROVE.as_text() in text
     assert 'wrapping' in text
+
+
+def test_to_text_grouped_annotations():
+    review = Review()
+    review.annotations.append(Annotation(
+        file=__file__,
+        lines=range(1, 3),
+        message='First comment on exact same block'))
+    review.annotations.append(Annotation(
+        file=__file__,
+        lines=range(1, 3),
+        message='Second comment on exact same block'))
+
+    text = review.to_text()
+    assert text.count('test_review.py') == 1
+    assert 'First comment on exact same block' in text
+    assert 'Second comment on exact same block' in text


### PR DESCRIPTION
When there are multiple annotations on the same line(s), group them together rather than generating a new thread. This makes the review easier to read and less verbose.

<details open>
<summary>Before</summary>

```
  🛑 Changes required
 /————————————————————————————————————————————————————————————————————————————\
 | For changes related to rosdep:                                             |
 | * 🛑 A YAML syntax error is blocking analysis                              |
 |                                                                            |
 | For changes related to yamllint:                                           |
 | * ❌ One or more linter violations were added to YAML files                |
 \————————————————————————————————————————————————————————————————————————————/
  ¦ 
  ¦ /—————————————————————————————————————————————————————————————————————————\
  ¦ | In rosdep/base.yaml:                                                    |
  ¦ |   6 |   ubuntu: [@libace-dev]                                           |
  ¦ +-------------------------------------------------------------------------+
  ¦ | YAML parsing error: found character '@' that cannot start any token     |
  ¦ | (while scanning for the next token)                                     |
  ¦ \—————————————————————————————————————————————————————————————————————————/
  ¦ 
  ¦ /—————————————————————————————————————————————————————————————————————————\
  ¦ | In rosdep/base.yaml:                                                    |
  ¦ |   6 |   ubuntu: [@libace-dev]                                           |
  ¦ +-------------------------------------------------------------------------+
  ¦ | This line does not pass YAML linter checks: syntax error: found         |
  ¦ | character '@' that cannot start any token (syntax)                      |
  ¦ \—————————————————————————————————————————————————————————————————————————/
```

</details>


<details open>
<summary>After</summary>

```
  🛑 Changes required
 /————————————————————————————————————————————————————————————————————————————\
 | For changes related to rosdep:                                             |
 | * 🛑 A YAML syntax error is blocking analysis                              |
 |                                                                            |
 | For changes related to yamllint:                                           |
 | * ❌ One or more linter violations were added to YAML files                |
 \————————————————————————————————————————————————————————————————————————————/
  ¦ 
  ¦ /—————————————————————————————————————————————————————————————————————————\
  ¦ | In rosdep/base.yaml:                                                    |
  ¦ |   6 |   ubuntu: [@libace-dev]                                           |
  ¦ +-------------------------------------------------------------------------+
  ¦ | YAML parsing error: found character '@' that cannot start any token     |
  ¦ | (while scanning for the next token)                                     |
  ¦ +-------------------------------------------------------------------------+
  ¦ | This line does not pass YAML linter checks: syntax error: found         |
  ¦ | character '@' that cannot start any token (syntax)                      |
  ¦ \—————————————————————————————————————————————————————————————————————————/
```

</details>

Assisted-by: Gemini 3.5 Flash