### PR TITLE
Add some basic ANSI colors to the ASCII review output

### DIFF
--- a/rosdistro_reviewer/review.py
+++ b/rosdistro_reviewer/review.py
@@ -16,9 +16,9 @@ from typing import Union
 
 
 def _should_use_color() -> bool:
-    if 'NO_COLOR' in os.environ:
+    if os.environ.get('NO_COLOR'):
         return False
-    elif 'FORCE_COLOR' in os.environ:
+    elif os.environ.get('FORCE_COLOR'):
         return True
     elif os.environ.get('TERM') == 'dumb':
         return False
@@ -55,14 +55,10 @@ def _bubblify_text(
     *,
     color: Optional[int] = None,
     border_color: Optional[int] = None,
-    boarder_color: Optional[int] = None,
 ) -> str:
     norm_color = f'\033[{color}m' if color is not None else None
-    actual_border = (
-        border_color if border_color is not None else boarder_color
-    )
     norm_border_color = (
-        f'\033[{actual_border}m' if actual_border is not None else None
+        f'\033[{border_color}m' if border_color is not None else None
     )
 
     top_border = '/' + ('—' * (width - 2)) + '\\'
@@ -138,14 +134,10 @@ def _format_code_block(
             if num >= lines.stop:
                 break
             if colored:
-                line_num = f'\033[90m  {num:>{digits}} |\033[0m '
-                code_content = line[:width - digits - 5].rstrip()
-                if code_content:
-                    code_content = f'\033[37m{code_content}\033[0m'
-                result += f'\n{line_num}{code_content}'
+                result += f'\n  \033[90m{num:>{digits}} |\033[0m '
             else:
                 result += f'\n  {num:>{digits}} | '
-                result += line[:width - digits - 5].rstrip()
+            result += line[:width - digits - 5].rstrip()
 
     return result
 

--- a/rosdistro_reviewer/review.py
+++ b/rosdistro_reviewer/review.py
@@ -4,8 +4,10 @@
 from collections import namedtuple
 from enum import IntEnum
 import itertools
+import os
 from pathlib import Path
 import re
+import sys
 import textwrap
 from typing import Dict
 from typing import List
@@ -13,13 +15,33 @@ from typing import Optional
 from typing import Union
 
 
+def _should_use_color() -> bool:
+    if 'NO_COLOR' in os.environ:
+        return False
+    elif 'FORCE_COLOR' in os.environ:
+        return True
+    elif os.environ.get('TERM') == 'dumb':
+        return False
+    else:
+        return (
+            sys.stdout.isatty()
+            if hasattr(sys.stdout, 'isatty')
+            else False
+        )
+
+
 def _printed_len(text: str) -> int:
-    return len(text) + sum(
-        text.count(r.as_symbol()) for r in Recommendation
+    stripped = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', text)
+    return len(stripped) + sum(
+        stripped.count(r.as_symbol()) for r in Recommendation
     )
 
 
 def _text_wrap(orig: str, width: int) -> List[str]:
+    stripped = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', orig)
+    if len(stripped) <= width:
+        return [orig]
+
     match = re.match(r'^(\s*[-*] )', orig)
     subsequent_indent = ' ' * len(match.group(1) if match else '')
     return textwrap.wrap(
@@ -27,8 +49,28 @@ def _text_wrap(orig: str, width: int) -> List[str]:
     ) or ['']
 
 
-def _bubblify_text(text: Union[str, List[str]], width: int = 78) -> str:
-    result = '/' + ('—' * (width - 2)) + '\\' + ''
+def _bubblify_text(
+    text: Union[str, List[str]],
+    width: int = 78,
+    *,
+    color: Optional[int] = None,
+    border_color: Optional[int] = None,
+    boarder_color: Optional[int] = None,
+) -> str:
+    norm_color = f'\033[{color}m' if color is not None else None
+    actual_border = (
+        border_color if border_color is not None else boarder_color
+    )
+    norm_border_color = (
+        f'\033[{actual_border}m' if actual_border is not None else None
+    )
+
+    top_border = '/' + ('—' * (width - 2)) + '\\'
+    result = (
+        f'{norm_border_color}{top_border}\033[0m'
+        if norm_border_color
+        else top_border
+    )
 
     if not isinstance(text, list):
         text = [text]
@@ -36,13 +78,39 @@ def _bubblify_text(text: Union[str, List[str]], width: int = 78) -> str:
     text_width = width - 4
     for idx, segment in enumerate(text):
         if idx:
-            result += '\n+' + ('-' * (width - 2)) + '+'
+            mid_sep = '+' + ('-' * (width - 2)) + '+'
+            result += '\n' + (
+                f'{norm_border_color}{mid_sep}\033[0m'
+                if norm_border_color
+                else mid_sep
+            )
         for line in segment.splitlines():
             for chunk in _text_wrap(line, text_width):
                 padding = ' ' * (text_width - _printed_len(chunk))
-                result += '\n| ' + chunk + padding + ' |'
 
-    result += '\n\\' + ('—' * (width - 2)) + '/'
+                if norm_border_color:
+                    left = f'{norm_border_color}|\033[0m '
+                    right = f' {norm_border_color}|\033[0m'
+                else:
+                    left = '| '
+                    right = ' |'
+
+                if norm_color:
+                    colored_chunk = chunk.replace(
+                        '\033[0m', f'\033[0m{norm_color}'
+                    )
+                    content = f'{norm_color}{colored_chunk}{padding}\033[0m'
+                else:
+                    content = chunk + padding
+
+                result += '\n' + left + content + right
+
+    bot_border = '\\' + ('—' * (width - 2)) + '/'
+    result += '\n' + (
+        f'{norm_border_color}{bot_border}\033[0m'
+        if norm_border_color
+        else bot_border
+    )
 
     return result
 
@@ -52,6 +120,7 @@ def _format_code_block(
     lines: range,
     width: int,
     root: Optional[Path] = None,
+    colored: bool = False,
 ) -> str:
     if root is None or not (root / file).is_file():
         if lines.start + 1 == lines.stop:
@@ -68,8 +137,15 @@ def _format_code_block(
         for num, line in enumerate(f, start=lines.start):
             if num >= lines.stop:
                 break
-            result += f'\n  {num:>{digits}} | '
-            result += line[:width - digits - 5].rstrip()
+            if colored:
+                line_num = f'\033[90m  {num:>{digits}} |\033[0m '
+                code_content = line[:width - digits - 5].rstrip()
+                if code_content:
+                    code_content = f'\033[37m{code_content}\033[0m'
+                result += f'\n{line_num}{code_content}'
+            else:
+                result += f'\n  {num:>{digits}} | '
+                result += line[:width - digits - 5].rstrip()
 
     return result
 
@@ -89,14 +165,22 @@ class Recommendation(IntEnum):
             Recommendation.APPROVE: '\U00002705',
         }[self]
 
-    def as_text(self) -> str:
+    def as_text(self, colored: bool = False) -> str:
         """Convert the recommendation to a shot text summary."""
-        return {
+        text = {
             Recommendation.DISAPPROVE: 'Changes recommended',
             Recommendation.NEUTRAL: 'No changes recommended, '
                                     'but requires further review',
             Recommendation.APPROVE: 'No changes recommended',
         }[self]
+        if colored:
+            color_code = {
+                Recommendation.DISAPPROVE: '\033[1;31m',
+                Recommendation.NEUTRAL: '\033[1;33m',
+                Recommendation.APPROVE: '\033[1;32m',
+            }[self]
+            return f'{color_code}{text}\033[0m'
+        return text
 
 
 Annotation = namedtuple('Annotation', ('file', 'lines', 'message'))
@@ -157,20 +241,32 @@ class Review:
 
         return message
 
-    def to_text(self, *, width: int = 80, root: Optional[Path] = None) -> str:
+    def to_text(
+        self,
+        *,
+        width: int = 80,
+        root: Optional[Path] = None,
+        colored: Optional[bool] = None,
+    ) -> str:
         """
         Generate a text representation of this review.
 
         :param width: Maximum number of columns in the output.
         :param root: Path to where code annotations can be resolved to. Used
           to prepend annotations with snippets of the code they refer to.
+        :param colored: Whether to colorize the output. If `None`, colors will
+          be auto-detected based on the environment and terminal.
         :returns: A string containing the text representation of the review.
         """
+        if colored is None:
+            colored = _should_use_color()
+
         message = self.summarize()
         recommendation = self.recommendation
 
+        rec_text = recommendation.as_text(colored=colored)
         result = textwrap.indent(
-            f' {recommendation.as_symbol()} {recommendation.as_text()}\n' +
+            f' {recommendation.as_symbol()} {rec_text}\n' +
             _bubblify_text(message, width=width - 2),
             ' ')
 
@@ -181,9 +277,10 @@ class Review:
                         annotation.file,
                         annotation.lines,
                         width=width - 9,
-                        root=root),
+                        root=root,
+                        colored=colored),
                     annotation.message,
-                ], width=width - 5),
+                ], width=width - 5, border_color=90 if colored else None),
                 '  ¦ ', predicate=lambda _: True)
 
         return result

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -22,6 +22,7 @@ github
 hexsha
 https
 india
+isatty
 isdigit
 iterdir
 itertools

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -3,12 +3,43 @@
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from rosdistro_reviewer.review import _should_use_color
 from rosdistro_reviewer.review import Annotation
 from rosdistro_reviewer.review import Criterion
 from rosdistro_reviewer.review import Recommendation
 from rosdistro_reviewer.review import Review
+
+
+def test_should_use_color() -> None:
+    with patch.dict(os.environ, {'NO_COLOR': '1'}, clear=True):
+        assert not _should_use_color()
+
+    with patch.dict(os.environ, {'FORCE_COLOR': '1'}, clear=True):
+        assert _should_use_color()
+
+    with patch.dict(
+        os.environ,
+        {'NO_COLOR': '1', 'FORCE_COLOR': '1'},
+        clear=True,
+    ):
+        assert not _should_use_color()
+
+    with patch.dict(os.environ, {'TERM': 'dumb'}, clear=True):
+        assert not _should_use_color()
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch('sys.stdout') as mock_stdout:
+            mock_stdout.isatty.return_value = True
+            assert _should_use_color()
+
+            mock_stdout.isatty.return_value = False
+            assert not _should_use_color()
+
+            del mock_stdout.isatty
+            assert not _should_use_color()
 
 
 @pytest.mark.parametrize(('colored',), (
@@ -16,6 +47,7 @@ from rosdistro_reviewer.review import Review
     (True,),
     (False,),
 ))
+@patch.dict(os.environ, {'NO_COLOR': '1'})
 def test_to_text(colored):
     review = Review()
     text = review.to_text(colored=colored)
@@ -39,8 +71,9 @@ def test_to_text(colored):
     assert 'Here is the license' in text
     assert 'Here is the whole header' in text
     assert 'foo' in text
-    assert Recommendation.APPROVE.as_text() in text
+    assert Recommendation.APPROVE.as_text(colored=colored) in text
     assert 'Things look great' in text
+    assert bool(colored) == ('\033[' in text)
 
     review.elements['bar'] = [
         Criterion(
@@ -57,5 +90,6 @@ def test_to_text(colored):
     text = review.to_text(root=Path(), colored=colored)
     assert 'annotates a file' in text
     assert 'bar' in text
-    assert Recommendation.DISAPPROVE.as_text() in text
+    assert Recommendation.DISAPPROVE.as_text(colored=colored) in text
     assert 'wrapping' in text
+    assert bool(colored) == ('\033[' in text)

--- a/test/test_review.py
+++ b/test/test_review.py
@@ -4,15 +4,21 @@
 import os
 from pathlib import Path
 
+import pytest
 from rosdistro_reviewer.review import Annotation
 from rosdistro_reviewer.review import Criterion
 from rosdistro_reviewer.review import Recommendation
 from rosdistro_reviewer.review import Review
 
 
-def test_to_text():
+@pytest.mark.parametrize(('colored',), (
+    (None,),
+    (True,),
+    (False,),
+))
+def test_to_text(colored):
     review = Review()
-    text = review.to_text()
+    text = review.to_text(colored=colored)
     assert Recommendation.NEUTRAL.as_text() in text
 
     review.annotations.append(Annotation(
@@ -29,7 +35,7 @@ def test_to_text():
             rationale='Things look great'),
     ]
 
-    text = review.to_text()
+    text = review.to_text(colored=colored)
     assert 'Here is the license' in text
     assert 'Here is the whole header' in text
     assert 'foo' in text
@@ -48,7 +54,7 @@ def test_to_text():
         lines=range(1, 2),
         message='This annotates a file which does not exist'))
 
-    text = review.to_text(root=Path())
+    text = review.to_text(root=Path(), colored=colored)
     assert 'annotates a file' in text
     assert 'bar' in text
     assert Recommendation.DISAPPROVE.as_text() in text


### PR DESCRIPTION
Subtle change to get some basic coloring. Nothing crazy (yet).

Example: https://htmlpreview.github.io/?https://gist.githubusercontent.com/cottsay/bfdd4534765416ad924b1391903fba0d/raw/rosdistro-reviewer.html

Assisted-by: Gemini 3.5 Flash